### PR TITLE
fix race conditions & avoid leaking goroutines

### DIFF
--- a/common/header.go
+++ b/common/header.go
@@ -5,6 +5,7 @@ package common
 import (
 	"encoding/binary"
 	"errors"
+	"sync/atomic"
 
 	"github.com/shaleman/libOpenflow/util"
 )
@@ -13,8 +14,8 @@ var messageXid uint32 = 1
 
 func NewHeaderGenerator(ver int) func() Header {
 	return func() Header {
-		messageXid += 1
-		p := Header{uint8(ver), 0, 8, messageXid}
+		xid := atomic.AddUint32(&messageXid, 1)
+		p := Header{uint8(ver), 0, 8, xid}
 		return p
 	}
 }

--- a/common/header.go
+++ b/common/header.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"sync/atomic"
 
-	"github.com/shaleman/libOpenflow/util"
+	"github.com/contiv/libOpenflow/util"
 )
 
 var messageXid uint32 = 1

--- a/openflow13/action.go
+++ b/openflow13/action.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/shaleman/libOpenflow/util"
+	"github.com/contiv/libOpenflow/util"
 )
 
 // ofp_action_type 1.3

--- a/openflow13/flowmod.go
+++ b/openflow13/flowmod.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/shaleman/libOpenflow/common"
+	"github.com/contiv/libOpenflow/common"
 )
 
 // ofp_flow_mod     1.3

--- a/openflow13/group.go
+++ b/openflow13/group.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/shaleman/libOpenflow/common"
+	"github.com/contiv/libOpenflow/common"
 )
 
 const (

--- a/openflow13/instruction.go
+++ b/openflow13/instruction.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/shaleman/libOpenflow/util"
+	"github.com/contiv/libOpenflow/util"
 )
 
 // ofp_instruction_type 1.3

--- a/openflow13/match.go
+++ b/openflow13/match.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/shaleman/libOpenflow/util"
+	"github.com/contiv/libOpenflow/util"
 )
 
 // ofp_match 1.3

--- a/openflow13/multipart.go
+++ b/openflow13/multipart.go
@@ -5,8 +5,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/shaleman/libOpenflow/common"
-	"github.com/shaleman/libOpenflow/util"
+	"github.com/contiv/libOpenflow/common"
+	"github.com/contiv/libOpenflow/util"
 )
 
 // ofp_multipart_request 1.3

--- a/openflow13/openflow13.go
+++ b/openflow13/openflow13.go
@@ -13,9 +13,9 @@ import (
 	"errors"
 	"net"
 
-	"github.com/shaleman/libOpenflow/common"
-	"github.com/shaleman/libOpenflow/protocol"
-	"github.com/shaleman/libOpenflow/util"
+	"github.com/contiv/libOpenflow/common"
+	"github.com/contiv/libOpenflow/protocol"
+	"github.com/contiv/libOpenflow/util"
 )
 
 const (

--- a/openflow13/port.go
+++ b/openflow13/port.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"net"
 
-	"github.com/shaleman/libOpenflow/common"
+	"github.com/contiv/libOpenflow/common"
 )
 
 // ofp_port 1.3

--- a/protocol/ethernet.go
+++ b/protocol/ethernet.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net"
 
-	"github.com/shaleman/libOpenflow/util"
+	"github.com/contiv/libOpenflow/util"
 )
 
 // see http://en.wikipedia.org/wiki/EtherType

--- a/protocol/icmp.go
+++ b/protocol/icmp.go
@@ -39,7 +39,7 @@ func (i *ICMP) UnmarshalBinary(data []byte) error {
 	i.Code = data[1]
 	i.Checksum = binary.BigEndian.Uint16(data[2:4])
 
-	for n, _ := range data[4:] {
+	for n := range data[4:] {
 		i.Data = append(i.Data, data[n])
 	}
 	return nil

--- a/protocol/ip.go
+++ b/protocol/ip.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net"
 
-	"github.com/shaleman/libOpenflow/util"
+	"github.com/contiv/libOpenflow/util"
 )
 
 const (

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,103 @@
+package libOpenflow
+
+import (
+	"io"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/contiv/libOpenflow/common"
+	"github.com/contiv/libOpenflow/openflow13"
+	"github.com/contiv/libOpenflow/util"
+)
+
+var helloMessage *common.Hello
+var binaryMessage []byte
+
+type fakeConn struct {
+	count int
+	max   int
+}
+
+func (f *fakeConn) Close() error {
+	return nil
+}
+
+func (f *fakeConn) Read(b []byte) (int, error) {
+	if f.count == f.max {
+		return 0, io.EOF
+	}
+	f.count++
+	copy(b, binaryMessage)
+	return len(binaryMessage), nil
+}
+
+func (f *fakeConn) Write(b []byte) (int, error) {
+	b, _ = helloMessage.MarshalBinary()
+	return len(b), nil
+}
+
+func (f *fakeConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (f *fakeConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (f *fakeConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (f *fakeConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (f *fakeConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+type parserIntf struct {
+}
+
+func (p parserIntf) Parse(b []byte) (message util.Message, err error) {
+	switch b[0] {
+	case openflow13.VERSION:
+		message, err = openflow13.Parse(b)
+	default:
+
+	}
+	return
+}
+
+func init() {
+	helloMessage, _ = common.NewHello(4)
+	binaryMessage, _ = helloMessage.MarshalBinary()
+
+}
+
+func TestMessageStream(t *testing.T) {
+	var (
+		c = &fakeConn{
+			max: 5000000,
+		}
+		p                   = parserIntf{}
+		goroutineCountStart = runtime.NumGoroutine()
+		goroutineCountEnd   int
+	)
+	logrus.SetLevel(logrus.PanicLevel)
+	stream := util.NewMessageStream(c, p)
+	go func() {
+		_ = <-stream.Error
+	}()
+	for i := 0; i < 5000000; i++ {
+		<-stream.Inbound
+	}
+	time.Sleep(2 * time.Second)
+	goroutineCountEnd = runtime.NumGoroutine()
+	if goroutineCountEnd > goroutineCountStart {
+		t.Fatalf("found more goroutines: %v before, %v after", goroutineCountStart, goroutineCountEnd)
+	}
+}


### PR DESCRIPTION
This PR makes the following changes:
- the first commit makes one gofmt fix to make gofmt happy
- the second commit adds locking for messageXid; this avoids some race conditions around the messageXid
- the third commit changes the code to avoid leaking goroutines in MessageStream & avoids races
The goroutines were leaking because there was no code to stop those goroutines before.
The races were related to reading from multiple goroutines and losing the order of the messages.

These changes have been tested with ofnet. I'll test with netplugin as well.

update:
This seems to be working fine in ofnet and in netplugin.