### PR TITLE
Add support for Nicira OpenFlow extension

### DIFF
--- a/openflow13/action.go
+++ b/openflow13/action.go
@@ -105,69 +105,11 @@ func DecodeAction(data []byte) (Action, error) {
 		// For Experimenter message, the length of action should be at least 10 bytes,
 		// including type(2 byte), length(2 byte), vendor(4 byte), and subtype(2 byte)
 		if len(data) < NxActionHeaderLength {
-			return nil, errors.New("The byte array has wrong size for openflow experimenter message")
+			return nil, errors.New("the []byte is too short to decode OpenFlow experimenter message")
 		}
 		v := binary.BigEndian.Uint32(data[4:8])
 		if v == NxExperimenterID {
-			subtype := binary.BigEndian.Uint16(data[8:])
-			switch subtype {
-			case NXAST_RESUBMIT:
-				a = new(NXActionResubmit)
-			case NXAST_SET_TUNNEL:
-			case NXAST_DROP_SPOOFED_ARP:
-			case NXAST_SET_QUEUE:
-			case NXAST_POP_QUEUE:
-			case NXAST_REG_MOVE:
-				a = new(NXActionRegMove)
-			case NXAST_REG_LOAD:
-				a = new(NXActionRegLoad)
-			case NXAST_NOTE:
-			case NXAST_SET_TUNNEL_V6:
-			case NXAST_MULTIPATH:
-			case NXAST_AUTOPATH:
-			case NXAST_BUNDLE:
-			case NXAST_BUNDLE_LOAD:
-			case NXAST_RESUBMIT_TABLE:
-				a = new(NXActionResubmitTable)
-			case NXAST_OUTPUT_REG:
-				a = newNXActionOutputReg()
-			case NXAST_LEARN:
-			case NXAST_EXIT:
-			case NXAST_DEC_TTL:
-				a = new(NXActionDecTTL)
-			case NXAST_FIN_TIMEOUT:
-			case NXAST_CONTROLLER:
-			case NXAST_DEC_TTL_CNT_IDS:
-				a = new(NXActionDecTTLCntIDs)
-			case NXAST_PUSH_MPLS:
-			case NXAST_POP_MPLS:
-			case NXAST_SET_MPLS_TTL:
-			case NXAST_DEC_MPLS_TTL:
-			case NXAST_STACK_PUSH:
-			case NXAST_STACK_POP:
-			case NXAST_SAMPLE:
-			case NXAST_SET_MPLS_LABEL:
-			case NXAST_SET_MPLS_TC:
-			case NXAST_OUTPUT_REG2:
-				a = new(NXActionOutputReg)
-			case NXAST_REG_LOAD2:
-			case NXAST_CNJUNCTION:
-				a = new(NXActionConjunction)
-			case NXAST_CT:
-				a = new(NXActionConnTrack)
-			case NXAST_NAT:
-				a = new(NXActionCTNAT)
-			case NXAST_CONTROLLER2:
-			case NXAST_SAMPLE2:
-			case NXAST_OUTPUT_TRUNC:
-			case NXAST_CT_CLEAR:
-			case NXAST_CT_RESUBMIT:
-				a = new(NXActionResubmitTable)
-				a.(*NXActionResubmitTable).withCT = true
-			case NXAST_RAW_ENCAP:
-			case NXAST_RAW_DECAP:
-			case NXAST_DEC_NSH_TTL:
-			}
+			a = DecodeNxAction(data)
 		}
 	}
 	err := a.UnmarshalBinary(data)

--- a/openflow13/action.go
+++ b/openflow13/action.go
@@ -65,7 +65,7 @@ func (a *ActionHeader) UnmarshalBinary(data []byte) error {
 }
 
 // Decode Action types.
-func DecodeAction(data []byte) Action {
+func DecodeAction(data []byte) (Action, error) {
 	t := binary.BigEndian.Uint16(data[:2])
 	var a Action
 	switch t {
@@ -94,16 +94,87 @@ func DecodeAction(data []byte) Action {
 	case ActionType_SetNwTtl:
 		a = new(ActionNwTtl)
 	case ActionType_DecNwTtl:
-		a = new(ActionHeader)
+		a = new(ActionDecNwTtl)
 	case ActionType_SetField:
 		a = new(ActionSetField)
 	case ActionType_PushPbb:
 		a = new(ActionPush)
 	case ActionType_PopPbb:
 		a = new(ActionHeader)
+	case ActionType_Experimenter:
+		// For Experimenter message, the length of action should be at least 10 bytes,
+		// including type(2 byte), length(2 byte), vendor(4 byte), and subtype(2 byte)
+		if len(data) < NxActionHeaderLength {
+			return nil, errors.New("The byte array has wrong size for openflow experimenter message")
+		}
+		v := binary.BigEndian.Uint32(data[4:8])
+		if v == NxExperimenterID {
+			subtype := binary.BigEndian.Uint16(data[8:])
+			switch subtype {
+			case NXAST_RESUBMIT:
+				a = new(NXActionResubmit)
+			case NXAST_SET_TUNNEL:
+			case NXAST_DROP_SPOOFED_ARP:
+			case NXAST_SET_QUEUE:
+			case NXAST_POP_QUEUE:
+			case NXAST_REG_MOVE:
+				a = new(NXActionRegMove)
+			case NXAST_REG_LOAD:
+				a = new(NXActionRegLoad)
+			case NXAST_NOTE:
+			case NXAST_SET_TUNNEL_V6:
+			case NXAST_MULTIPATH:
+			case NXAST_AUTOPATH:
+			case NXAST_BUNDLE:
+			case NXAST_BUNDLE_LOAD:
+			case NXAST_RESUBMIT_TABLE:
+				a = new(NXActionResubmitTable)
+			case NXAST_OUTPUT_REG:
+				a = newNXActionOutputReg()
+			case NXAST_LEARN:
+			case NXAST_EXIT:
+			case NXAST_DEC_TTL:
+				a = new(NXActionDecTTL)
+			case NXAST_FIN_TIMEOUT:
+			case NXAST_CONTROLLER:
+			case NXAST_DEC_TTL_CNT_IDS:
+				a = new(NXActionDecTTLCntIDs)
+			case NXAST_PUSH_MPLS:
+			case NXAST_POP_MPLS:
+			case NXAST_SET_MPLS_TTL:
+			case NXAST_DEC_MPLS_TTL:
+			case NXAST_STACK_PUSH:
+			case NXAST_STACK_POP:
+			case NXAST_SAMPLE:
+			case NXAST_SET_MPLS_LABEL:
+			case NXAST_SET_MPLS_TC:
+			case NXAST_OUTPUT_REG2:
+				a = new(NXActionOutputReg)
+			case NXAST_REG_LOAD2:
+			case NXAST_CNJUNCTION:
+				a = new(NXActionConjunction)
+			case NXAST_CT:
+				a = new(NXActionConnTrack)
+			case NXAST_NAT:
+				a = new(NXActionCTNAT)
+			case NXAST_CONTROLLER2:
+			case NXAST_SAMPLE2:
+			case NXAST_OUTPUT_TRUNC:
+			case NXAST_CT_CLEAR:
+			case NXAST_CT_RESUBMIT:
+				a = new(NXActionResubmitTable)
+				a.(*NXActionResubmitTable).withCT = true
+			case NXAST_RAW_ENCAP:
+			case NXAST_RAW_DECAP:
+			case NXAST_DEC_NSH_TTL:
+			}
+		}
 	}
-	a.UnmarshalBinary(data)
-	return a
+	err := a.UnmarshalBinary(data)
+	if err != nil {
+		return a, err
+	}
+	return a, nil
 }
 
 // Action structure for OFPAT_OUTPUT, which sends packets out ’port’.
@@ -260,6 +331,39 @@ type ActionMplsTtl struct {
 	ActionHeader
 	MplsTtl uint8
 	pad     []byte // 3bytes
+}
+
+type ActionDecNwTtl struct {
+	ActionHeader
+	pad []byte // 4bytes
+}
+
+func NewActionDecNwTtl() *ActionDecNwTtl {
+	act := new(ActionDecNwTtl)
+	act.Type = ActionType_DecNwTtl
+	act.Length = 8
+	act.pad = make([]byte, 4)
+	return act
+}
+
+func (a *ActionDecNwTtl) Len() (n uint16) {
+	return a.ActionHeader.Len() + 4
+}
+
+func (a *ActionDecNwTtl) MarshalBinary() (data []byte, err error) {
+	data, err = a.ActionHeader.MarshalBinary()
+	if err != nil {
+		return
+	}
+
+	// Padding
+	bytes := make([]byte, 4)
+	data = append(data, bytes...)
+	return
+}
+
+func (a *ActionDecNwTtl) UnmarshalBinary(data []byte) error {
+	return a.ActionHeader.UnmarshalBinary(data[:4])
 }
 
 type ActionNwTtl struct {

--- a/openflow13/group.go
+++ b/openflow13/group.go
@@ -198,7 +198,7 @@ func (b *Bucket) UnmarshalBinary(data []byte) error {
 	n += 4 // for padding
 
 	for n < int(b.Length) {
-		a := DecodeAction(data[n:])
+		a, _ := DecodeAction(data[n:])
 		b.Actions = append(b.Actions, a)
 		n += int(a.Len())
 	}

--- a/openflow13/group.go
+++ b/openflow13/group.go
@@ -198,7 +198,10 @@ func (b *Bucket) UnmarshalBinary(data []byte) error {
 	n += 4 // for padding
 
 	for n < int(b.Length) {
-		a, _ := DecodeAction(data[n:])
+		a, err := DecodeAction(data[n:])
+		if err != nil {
+			return err
+		}
 		b.Actions = append(b.Actions, a)
 		n += int(a.Len())
 	}

--- a/openflow13/instruction.go
+++ b/openflow13/instruction.go
@@ -204,7 +204,10 @@ func (instr *InstrActions) UnmarshalBinary(data []byte) error {
 
 	n := 8
 	for n < int(instr.Length) {
-		act, _ := DecodeAction(data[n:])
+		act, err := DecodeAction(data[n:])
+		if err != nil {
+			return err
+		}
 		instr.Actions = append(instr.Actions, act)
 		n += int(act.Len())
 	}

--- a/openflow13/instruction.go
+++ b/openflow13/instruction.go
@@ -204,7 +204,7 @@ func (instr *InstrActions) UnmarshalBinary(data []byte) error {
 
 	n := 8
 	for n < int(instr.Length) {
-		act := DecodeAction(data[n:])
+		act, _ := DecodeAction(data[n:])
 		instr.Actions = append(instr.Actions, act)
 		n += int(act.Len())
 	}

--- a/openflow13/match.go
+++ b/openflow13/match.go
@@ -1331,6 +1331,36 @@ func NewTunnelIpv4DstField(tunnelIpDst net.IP, tunnelIpDstMask *net.IP) *MatchFi
 	return f
 }
 
+// SCTP_DST field
+func NewSctpDstField(port uint16) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_SCTP_DST
+	f.HasMask = false
+
+	sctpDstField := new(PortField)
+	sctpDstField.port = port
+	f.Value = sctpDstField
+	f.Length = uint8(sctpDstField.Len())
+
+	return f
+}
+
+// SCTP_DST field
+func NewSctpSrcField(port uint16) *MatchField {
+	f := new(MatchField)
+	f.Class = OXM_CLASS_OPENFLOW_BASIC
+	f.Field = OXM_FIELD_SCTP_SRC
+	f.HasMask = false
+
+	sctpSrcField := new(PortField)
+	sctpSrcField.port = port
+	f.Value = sctpSrcField
+	f.Length = uint8(sctpSrcField.Len())
+
+	return f
+}
+
 // ARP Host Address field message, used by arp_sha and arp_tha match
 type ArpXHaField struct {
 	arpHa net.HardwareAddr

--- a/openflow13/match.go
+++ b/openflow13/match.go
@@ -188,14 +188,14 @@ func (m *MatchField) MarshalHeader() uint32 {
 func (m *MatchField) UnmarshalHeader(data []byte) error {
 	var err error
 	if len(data) < int(4) {
-		err = fmt.Errorf("the byte array has wrong size to unmarshal MatchField header")
+		err = fmt.Errorf("the []byte is too short to unmarshal MatchField header")
 		return err
 	}
 	n := 0
 	m.Class = binary.BigEndian.Uint16(data[n:])
 	n += 2
 	fieldWithMask := data[n]
-	m.HasMask = bool(fieldWithMask&1 == 1)
+	m.HasMask = fieldWithMask&1 == 1
 	m.Field = fieldWithMask >> 1
 	n += 1
 	m.Length = data[n] & 0xff

--- a/openflow13/nx_action.go
+++ b/openflow13/nx_action.go
@@ -1,0 +1,943 @@
+package openflow13
+
+import (
+	"encoding/binary"
+	"errors"
+	"math"
+	"net"
+)
+
+const (
+	NxExperimenterID     = 0x00002320 // Experimenter_ID for Nicira extension messages
+	NxActionHeaderLength = 10         // Length of Nicira extension message header
+
+	NXAST_RESUBMIT         = 1  // Nicira extended action: resubmit(port)
+	NXAST_SET_TUNNEL       = 2  // Nicira extended action: set_tunnel
+	NXAST_DROP_SPOOFED_ARP = 3  // Nicira extended action: drop spoofed arp packets
+	NXAST_SET_QUEUE        = 4  // Nicira extended action: set_queue
+	NXAST_POP_QUEUE        = 5  // Nicira extended action: pop_tunnel
+	NXAST_REG_MOVE         = 6  // Nicira extended action: move:srcField[m1..n1]->dstField[m2..n2]
+	NXAST_REG_LOAD         = 7  // Nicira extended action: load:data->dstField[m..n]
+	NXAST_NOTE             = 8  // Nicira extended action: note
+	NXAST_SET_TUNNEL_V6    = 9  // Nicira extended action: set_tunnel64
+	NXAST_MULTIPATH        = 10 // Nicira extended action: set_tunnel
+	NXAST_AUTOPATH         = 11 // Nicira extended action: multipath
+	NXAST_BUNDLE           = 12 // Nicira extended action: bundle
+	NXAST_BUNDLE_LOAD      = 13 // Nicira extended action: bundle_load
+	NXAST_RESUBMIT_TABLE   = 14 // Nicira extended action: resubmit(port, table)
+	NXAST_OUTPUT_REG       = 15 // Nicira extended action: output:field
+	NXAST_LEARN            = 16 // Nicira extended action: learn
+	NXAST_EXIT             = 17 // Nicira extended action: exit
+	NXAST_DEC_TTL          = 18 // Nicira extended action: dec_ttl
+	NXAST_FIN_TIMEOUT      = 19 // Nicira extended action: output:field
+	NXAST_CONTROLLER       = 20 // Nicira extended action: fin_timeout
+	NXAST_DEC_TTL_CNT_IDS  = 21 // Nicira extended action: dec_ttl(id1,[id2]...)
+	NXAST_PUSH_MPLS        = 23 // Nicira extended action: push_mpls
+	NXAST_POP_MPLS         = 24 // Nicira extended action: pop_mpls
+	NXAST_SET_MPLS_TTL     = 25 // Nicira extended action: set_mpls_ttl
+	NXAST_DEC_MPLS_TTL     = 26 // Nicira extended action: set_mpls_ttl
+	NXAST_STACK_PUSH       = 27 // Nicira extended action: push:src
+	NXAST_STACK_POP        = 28 // Nicira extended action: pop:dst
+	NXAST_SAMPLE           = 29 // Nicira extended action: sample
+	NXAST_SET_MPLS_LABEL   = 30 // Nicira extended action: set_mpls_label
+	NXAST_SET_MPLS_TC      = 31 // Nicira extended action: set_mpls_tc
+	NXAST_OUTPUT_REG2      = 32 // Nicira extended action: output(port=port,max_len)
+	NXAST_REG_LOAD2        = 33 // Nicira extended action: load
+	NXAST_CNJUNCTION       = 34 // Nicira extended action: conjunction
+	NXAST_CT               = 35 // Nicira extended action: ct
+	NXAST_NAT              = 36 // Nicira extended action: nat, need to be along with ct action
+	NXAST_CONTROLLER2      = 37 // Nicira extended action: controller(userdata=xxx,pause)
+	NXAST_SAMPLE2          = 38 // Nicira extended action: sample, support for exporting egress tunnel
+	NXAST_OUTPUT_TRUNC     = 39 // Nicira extended action: truncate output action
+	NXAST_CT_CLEAR         = 43 // Nicira extended action: ct_clear
+	NXAST_CT_RESUBMIT      = 44 // Nicira extended action: resubmit to table in ct
+	NXAST_RAW_ENCAP        = 46 // Nicira extended action: encap
+	NXAST_RAW_DECAP        = 47 // Nicira extended action: decap
+	NXAST_DEC_NSH_TTL      = 48 // Nicira extended action: dec_nsh_ttl
+)
+
+type NXActionHeader struct {
+	*ActionHeader
+	Vendor  uint32
+	Subtype uint16
+}
+
+func (a *NXActionHeader) Header() *ActionHeader {
+	return a.ActionHeader
+}
+
+func (a *NXActionHeader) NXHeader() *NXActionHeader {
+	return a
+}
+
+func (a *NXActionHeader) Len() (n uint16) {
+	return NxActionHeaderLength
+}
+
+func (a *NXActionHeader) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, a.Len())
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.ActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint32(data[n:], a.Vendor)
+	n += 4
+	binary.BigEndian.PutUint16(data[n:], a.Subtype)
+	return
+}
+
+func (a *NXActionHeader) UnmarshalBinary(data []byte) error {
+	if len(data) < int(NxActionHeaderLength) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionHeader message.")
+	}
+	a.ActionHeader = new(ActionHeader)
+	n := 0
+	err := a.ActionHeader.UnmarshalBinary(data[:4])
+	n += 4
+	a.Vendor = binary.BigEndian.Uint32(data[n:])
+	n += 4
+	a.Subtype = binary.BigEndian.Uint16(data[n:])
+	return err
+}
+
+func NewNxActionHeader(subtype uint16) *NXActionHeader {
+	actionHeader := &ActionHeader{Type: ActionType_Experimenter, Length: NxActionHeaderLength}
+	return &NXActionHeader{ActionHeader: actionHeader, Vendor: NxExperimenterID, Subtype: subtype}
+}
+
+// nxast_conjunction
+type NXActionConjunction struct {
+	*NXActionHeader
+	Clause  uint8
+	NClause uint8
+	ID      uint32
+}
+
+// conjunction(ID, Clause/nclause)
+func NewNXActionConjunction(clause uint8, nclause uint8, id uint32) *NXActionConjunction {
+	a := new(NXActionConjunction)
+	a.NXActionHeader = NewNxActionHeader(NXAST_CNJUNCTION)
+	a.Length = a.NXActionHeader.Len() + 6
+	a.Clause = clause
+	a.NClause = nclause
+	a.ID = id
+	return a
+}
+
+func (a *NXActionConjunction) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionConjunction) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	data[n] = a.Clause
+	n += 1
+	data[n] = a.NClause
+	n += 1
+	binary.BigEndian.PutUint32(data[n:], a.ID)
+	n += 4
+
+	return
+}
+
+func (a *NXActionConjunction) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionConjunction message")
+	}
+	a.Clause = uint8(data[n])
+	n += 1
+	a.NClause = uint8(data[n])
+	n += 1
+	a.ID = binary.BigEndian.Uint32(data[n:])
+
+	return err
+}
+
+// nx_action_conntrack
+type NXActionConnTrack struct {
+	*NXActionHeader
+	Flags        uint16
+	ZoneSrc      uint32
+	ZoneOfsNbits uint16
+	RecircTable  uint8
+	pad          []byte // 3bytes
+	Alg          uint16
+	actions      []Action
+}
+
+func (a *NXActionConnTrack) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionConnTrack) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Length))
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.Flags)
+	n += 2
+	binary.BigEndian.PutUint32(data[n:], a.ZoneSrc)
+	n += 4
+	binary.BigEndian.PutUint16(data[n:], a.ZoneOfsNbits)
+	n += 2
+	data[n] = a.RecircTable
+	n += 1
+	copy(data[n:], a.pad)
+	n += 3
+	binary.BigEndian.PutUint16(data[n:], a.Alg)
+	n += 2
+	// Marshal ct actions
+	for _, action := range a.actions {
+		actionBytes, err := action.MarshalBinary()
+		if err != nil {
+			return data, errors.New("failed to Marshal ct subActions")
+		}
+		copy(data[n:], actionBytes)
+		n += len(actionBytes)
+	}
+	return
+}
+
+func (a *NXActionConnTrack) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionConnTrack message")
+	}
+	a.Flags = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.ZoneSrc = binary.BigEndian.Uint32(data[n:])
+	n += 4
+	a.ZoneOfsNbits = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.RecircTable = data[n]
+	n += 1
+	copy(a.pad, data[n:n+3])
+	n += 3
+	a.Alg = binary.BigEndian.Uint16(data[n:])
+	n += 2
+
+	for n < int(a.Len()) {
+		act, err := DecodeAction(data[n:])
+		if err != nil {
+			return errors.New("failed to decode actions")
+		}
+		a.actions = append(a.actions, act)
+		n += int(act.Len())
+	}
+	a.Length = uint16(n)
+	return err
+}
+
+func (a *NXActionConnTrack) Commit() *NXActionConnTrack {
+	a.Flags |= NX_CT_F_COMMIT
+	return a
+}
+
+func (a *NXActionConnTrack) Force() *NXActionConnTrack {
+	a.Flags |= NX_CT_F_FORCE
+	return a
+}
+
+func (a *NXActionConnTrack) Table(tableID uint8) *NXActionConnTrack {
+	a.RecircTable = tableID
+	return a
+}
+
+func (a *NXActionConnTrack) ZoneImm(zoneID uint16) *NXActionConnTrack {
+	a.ZoneSrc = 0
+	a.ZoneOfsNbits = zoneID
+	return a
+}
+
+func (a *NXActionConnTrack) ZoneRange(field *MatchField, rng *NXRange) *NXActionConnTrack {
+	a.ZoneSrc = field.MarshalHeader()
+	a.ZoneOfsNbits = rng.ToOfsBits()
+	return a
+}
+
+func (a *NXActionConnTrack) AddAction(actions ...Action) *NXActionConnTrack {
+	for _, act := range actions {
+		a.actions = append(a.actions, act)
+		a.Length += act.Len()
+	}
+	return a
+}
+
+func NewNXActionConnTrack() *NXActionConnTrack {
+	a := new(NXActionConnTrack)
+	a.NXActionHeader = NewNxActionHeader(NXAST_CT)
+	a.Length = a.NXActionHeader.Len() + 14
+	a.RecircTable = NX_CT_RECIRC_NONE
+	return a
+}
+
+// nx_action_reg_load
+type NXActionRegLoad struct {
+	*NXActionHeader
+	OfsNbits uint16
+	DstReg   *MatchField
+	Value    uint64
+}
+
+func NewNXActionRegLoad(ofsNbits uint16, dstField *MatchField, value uint64) *NXActionRegLoad {
+	a := new(NXActionRegLoad)
+	a.NXActionHeader = NewNxActionHeader(NXAST_REG_LOAD)
+	a.Length = a.NXActionHeader.Len() + 14
+	a.OfsNbits = ofsNbits
+	a.DstReg = dstField
+	a.Value = value
+	return a
+}
+
+func (a *NXActionRegLoad) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionRegLoad) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.OfsNbits)
+	n += 2
+	fieldHeaderData := a.DstReg.MarshalHeader()
+	binary.BigEndian.PutUint32(data[n:], fieldHeaderData)
+	n += 4
+	binary.BigEndian.PutUint64(data[n:], a.Value)
+	n += 8
+
+	return
+}
+
+func (a *NXActionRegLoad) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionRegLoad message")
+	}
+	a.OfsNbits = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.DstReg = new(MatchField)
+	err = a.DstReg.UnmarshalHeader(data[n : n+4])
+	n += 4
+	a.Value = binary.BigEndian.Uint64(data[n:])
+	return err
+}
+
+// nx_action_reg_move
+type NXActionRegMove struct {
+	*NXActionHeader
+	Nbits    uint16
+	SrcOfs   uint16
+	DstOfs   uint16
+	SrcField *MatchField
+	DstField *MatchField
+}
+
+func NewNXActionRegMove(nBits uint16, srcOfs uint16, dstOfs uint16, srcField *MatchField, dstField *MatchField) *NXActionRegMove {
+	a := new(NXActionRegMove)
+	a.NXActionHeader = NewNxActionHeader(NXAST_REG_MOVE)
+	a.Length = a.NXActionHeader.Len() + 14
+	a.Nbits = nBits
+	a.SrcOfs = srcOfs
+	a.DstOfs = dstOfs
+	a.SrcField = srcField
+	a.DstField = dstField
+	return a
+}
+
+func (a *NXActionRegMove) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionRegMove) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, a.Length)
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.Nbits)
+	n += 2
+	binary.BigEndian.PutUint16(data[n:], a.SrcOfs)
+	n += 2
+	binary.BigEndian.PutUint16(data[n:], a.DstOfs)
+	n += 2
+
+	srcFieldHeaderData := a.SrcField.MarshalHeader()
+	binary.BigEndian.PutUint32(data[n:], srcFieldHeaderData)
+	n += 4
+
+	dstFieldHeaderData := a.DstField.MarshalHeader()
+	binary.BigEndian.PutUint32(data[n:], dstFieldHeaderData)
+	n += 4
+	return
+}
+
+func (a *NXActionRegMove) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionRegLoad message")
+	}
+	a.Nbits = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.SrcOfs = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.DstOfs = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.SrcField = new(MatchField)
+	err = a.SrcField.UnmarshalHeader(data[n:])
+	n += 4
+	a.DstField = new(MatchField)
+	err = a.DstField.UnmarshalHeader(data[n:])
+	return err
+}
+
+type NXActionResubmit struct {
+	*NXActionHeader
+	InPort  uint16
+	TableID uint8
+	pad     [3]byte // 3 bytes
+}
+
+func NewNXActionResubmit(inPort uint16) *NXActionResubmit {
+	a := new(NXActionResubmit)
+	a.NXActionHeader = NewNxActionHeader(NXAST_RESUBMIT)
+	a.Type = Type_Experimenter
+	a.Length = a.NXActionHeader.Len() + 6
+	a.InPort = inPort
+	a.pad = [3]byte{}
+	return a
+}
+
+func (a *NXActionResubmit) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionResubmit) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.InPort)
+	n += 2
+	a.TableID = OFPTT_ALL
+	n += 1
+	n += 3
+
+	return
+}
+
+func (a *NXActionResubmit) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionConjunction message")
+	}
+	a.InPort = binary.BigEndian.Uint16(data[n:])
+
+	return err
+}
+
+// nxast_resubmit_table
+type NXActionResubmitTable struct {
+	*NXActionHeader
+	InPort  uint16
+	TableID uint8
+	pad     [3]byte // 3 bytes
+	withCT  bool
+}
+
+func newNXActionResubmitTable() *NXActionResubmitTable {
+	a := &NXActionResubmitTable{
+		NXActionHeader: NewNxActionHeader(NXAST_RESUBMIT_TABLE),
+		withCT:         false,
+		pad:            [3]byte{},
+	}
+	a.Length = 16
+	return a
+}
+
+func newNXActionResubmitTableCT() *NXActionResubmitTable {
+	a := &NXActionResubmitTable{
+		NXActionHeader: NewNxActionHeader(NXAST_RESUBMIT_TABLE),
+		withCT:         true,
+		pad:            [3]byte{},
+	}
+	a.Length = 16
+	return a
+}
+
+func NewNXActionResubmitTableAction(inPort uint16, tableId uint8) *NXActionResubmitTable {
+	a := newNXActionResubmitTable()
+	a.InPort = inPort
+	a.TableID = tableId
+	return a
+}
+
+func (a *NXActionResubmitTable) IsCT() bool {
+	return a.withCT
+}
+
+func (a *NXActionResubmitTable) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionResubmitTable) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.InPort)
+	n += 2
+	data[n] = a.TableID
+	n += 1
+	n += 3
+
+	return
+}
+
+func (a *NXActionResubmitTable) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionResubmitTable message")
+	}
+	a.InPort = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.TableID = data[n]
+	n += 1
+
+	return err
+}
+
+func NewNXActionResubmitTableCT(inPort uint16, tableId uint8) *NXActionResubmitTable {
+	a := newNXActionResubmitTableCT()
+	a.InPort = inPort
+	a.TableID = tableId
+	return a
+}
+
+func NewNXActionResubmitTableCTNoInPort(tableId uint8) *NXActionResubmitTable {
+	a := newNXActionResubmitTableCT()
+	a.InPort = OFPP_IN_PORT
+	a.TableID = tableId
+	return a
+}
+
+// nxast_resubmit_table
+type NXActionCTNAT struct {
+	*NXActionHeader
+	pad          []byte // 2 bytes
+	Flags        uint16 // nat Flags to identify snat/dnat, and nat algorithms: random/protocolHash, connection persistent
+	rangePresent uint16 // mark if has set nat range, including ipv4/ipv6 range, port range
+
+	rangeIPv4Min  net.IP
+	rangeIPv4Max  net.IP
+	rangeIPv6Min  net.IP
+	rangeIPv6Max  net.IP
+	rangeProtoMin *uint16
+	rangeProtoMax *uint16
+}
+
+func NewNXActionCTNAT() *NXActionCTNAT {
+	a := new(NXActionCTNAT)
+	a.NXActionHeader = NewNxActionHeader(NXAST_NAT)
+	a.Length = 16
+	a.pad = make([]byte, 2, 2)
+	return a
+}
+
+func (a *NXActionCTNAT) Len() (n uint16) {
+	a.Length = uint16(math.Ceil(float64(a.Length)/float64(8))) * 8
+	return a.Length
+}
+
+func (a *NXActionCTNAT) MarshalBinary() (data []byte, err error) {
+	optData := make([]byte, 0)
+	optN := 0
+	if a.rangeIPv4Min != nil {
+		optData = append(optData[optN:], a.rangeIPv4Min.To4()...)
+		optN += 4
+	}
+	if a.rangeIPv4Max != nil {
+		optData = append(optData[optN:], a.rangeIPv4Max.To4()...)
+		optN += 4
+	}
+	if a.rangeIPv6Min != nil {
+		optData = append(optData[optN:], a.rangeIPv6Min.To16()...)
+		optN += 16
+	}
+	if a.rangeIPv6Max != nil {
+		optData = append(optData[optN:], a.rangeIPv6Max.To16()...)
+		optN += 16
+	}
+	if a.rangeProtoMin != nil {
+		binary.BigEndian.PutUint16(optData[optN:], *a.rangeProtoMin)
+		optN += 2
+	}
+	if a.rangeProtoMin != nil {
+		binary.BigEndian.PutUint16(optData[optN:], *a.rangeProtoMax)
+		optN += 2
+	}
+
+	data = make([]byte, a.Len())
+	b := make([]byte, a.NXActionHeader.Len())
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	copy(data[n:], a.pad)
+	n += 2
+	binary.BigEndian.PutUint16(data[n:], a.Flags)
+	n += 2
+	binary.BigEndian.PutUint16(data[n:], a.rangePresent)
+	n += 2
+	copy(data[n:], optData)
+	n += optN
+
+	// padding the message if the length is not an integer multiple of 8 bytes
+	if n < int(a.Length) {
+		var padN = int(a.Length) - n
+		pad := make([]byte, padN, padN)
+		copy(optData, pad)
+		a.Length = a.Len()
+	}
+	return
+}
+
+func (a *NXActionCTNAT) SetSNAT() error {
+	if a.Flags&(^uint16(NX_NAT_F_MASK)) != 0 || a.Flags&NX_NAT_F_DST != 0 {
+		return errors.New("SNAT action should be exclusively with DNAT")
+	}
+	a.Flags |= NX_NAT_F_SRC
+	return nil
+}
+
+func (a *NXActionCTNAT) SetDNAT() error {
+	if a.Flags&NX_NAT_F_SRC != 0 {
+		return errors.New("DNAT action should be exclusively with SNAT")
+	}
+	a.Flags |= NX_NAT_F_DST
+	return nil
+}
+
+func (a *NXActionCTNAT) SetProtoHash() error {
+	if a.Flags&NX_NAT_F_PROTO_RANDOM != 0 {
+		return errors.New("protocol hash should be exclusively with random")
+	}
+	a.Flags |= NX_NAT_F_PROTO_HASH
+	return nil
+}
+
+func (a *NXActionCTNAT) SetRandom() error {
+	if a.Flags&NX_NAT_F_PROTO_HASH != 0 {
+		return errors.New("random should be exclusively with protocol hash")
+	}
+	a.Flags |= NX_NAT_F_PROTO_RANDOM
+	return nil
+}
+
+func (a *NXActionCTNAT) SetPersistent() error {
+	a.Flags |= NX_NAT_F_PERSISTENT
+	return nil
+}
+
+func (a *NXActionCTNAT) SetRangeIPv4Min(ipMin net.IP) {
+	a.rangeIPv4Min = ipMin
+	a.rangePresent |= NX_NAT_RANGE_IPV4_MIN
+	a.Length += 4
+}
+func (a *NXActionCTNAT) SetRangeIPv4Max(ipMax net.IP) {
+	a.rangeIPv4Max = ipMax
+	a.rangePresent |= NX_NAT_RANGE_IPV4_MAX
+	a.Length += 4
+}
+func (a *NXActionCTNAT) SetRangeIPv6Min(ipMin net.IP) {
+	a.rangeIPv6Min = ipMin
+	a.rangePresent |= NX_NAT_RANGE_IPV6_MIN
+	a.Length += 16
+}
+func (a *NXActionCTNAT) SetRangeIPv6Max(ipMax net.IP) {
+	a.rangeIPv6Max = ipMax
+	a.rangePresent |= NX_NAT_RANGE_IPV6_MAX
+	a.Length += 16
+}
+func (a *NXActionCTNAT) SetRangeProtoMin(protoMin *uint16) {
+	a.rangeProtoMin = protoMin
+	a.rangePresent |= NX_NAT_RANGE_PROTO_MIN
+	a.Length += 2
+}
+func (a *NXActionCTNAT) SetRangeProtoMax(protoMax *uint16) {
+	a.rangeProtoMax = protoMax
+	a.rangePresent |= NX_NAT_RANGE_PROTO_MAX
+	a.Length += 2
+}
+
+func (a *NXActionCTNAT) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionCTNAT message")
+	}
+	copy(a.pad, data[n:n+2])
+	n += 2
+	a.Flags = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.rangePresent = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	if a.rangePresent&NX_NAT_RANGE_IPV4_MIN != 0 {
+		a.rangeIPv4Min = net.IPv4(data[n], data[n+1], data[n+2], data[n+3])
+		n += 4
+	}
+	if a.rangePresent&NX_NAT_RANGE_IPV4_MAX != 0 {
+		a.rangeIPv4Max = net.IPv4(data[n], data[n+1], data[n+2], data[n+3])
+		n += 4
+	}
+	if a.rangePresent&NX_NAT_RANGE_IPV6_MIN != 0 {
+		a.rangeIPv6Min = make([]byte, 16)
+		copy(a.rangeIPv6Min, data[n:n+16])
+		n += 16
+	}
+	if a.rangePresent&NX_NAT_RANGE_IPV6_MAX != 0 {
+		a.rangeIPv6Max = make([]byte, 16)
+		copy(a.rangeIPv6Max, data[n:n+16])
+		n += 16
+	}
+	if a.rangePresent&NX_NAT_RANGE_PROTO_MIN != 0 {
+		portMin := binary.BigEndian.Uint16(data[n:])
+		a.rangeProtoMin = &portMin
+		n += 2
+	}
+	if a.rangePresent&NX_NAT_RANGE_PROTO_MAX != 0 {
+		portMax := binary.BigEndian.Uint16(data[n:])
+		a.rangeProtoMin = &portMax
+		n += 2
+	}
+
+	return err
+}
+
+// nx_action_output_reg
+type NXActionOutputReg struct {
+	*NXActionHeader
+	OfsNbits uint16      // (ofs << 6 | (Nbits -1)
+	SrcField *MatchField // source nxm_nx_reg
+	MaxLen   uint16      // Max length to send to controller if chosen port is OFPP_CONTROLLER
+	zero     []uint8     // 6 uint8 with all Value as 0, reserved
+}
+
+func (a *NXActionOutputReg) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionOutputReg) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.OfsNbits)
+	n += 2
+	fieldHeaderData := a.SrcField.MarshalHeader()
+	binary.BigEndian.PutUint32(data[n:], fieldHeaderData)
+	n += 4
+	binary.BigEndian.PutUint16(data[n:], a.MaxLen)
+	n += 2
+	copy(data[n:], a.zero)
+	n += 6
+
+	return
+}
+
+func (a *NXActionOutputReg) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionOutputReg message")
+	}
+	a.OfsNbits = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.SrcField = new(MatchField)
+	err = a.SrcField.UnmarshalHeader(data[n : n+4])
+	n += 4
+	a.MaxLen = binary.BigEndian.Uint16(data[n:])
+	return err
+}
+
+func newNXActionOutputReg() *NXActionOutputReg {
+	a := &NXActionOutputReg{
+		NXActionHeader: NewNxActionHeader(NXAST_OUTPUT_REG),
+		zero:           make([]uint8, 6, 6),
+	}
+	a.Length = 24
+	return a
+}
+
+func NewOutputFromField(srcField *MatchField, ofsNbits uint16) *NXActionOutputReg {
+	a := newNXActionOutputReg()
+	a.SrcField = srcField
+	a.OfsNbits = ofsNbits
+	a.MaxLen = uint16(0xffff)
+	return a
+}
+
+func NewOutputFromFieldWithMaxLen(srcField *MatchField, ofsNbits uint16, maxLen uint16) *NXActionOutputReg {
+	a := newNXActionOutputReg()
+	a.SrcField = srcField
+	a.OfsNbits = ofsNbits
+	a.MaxLen = maxLen
+	return a
+}
+
+type NXActionDecTTL struct {
+	*NXActionHeader
+	controllers uint16   // number of controller
+	zeros       [4]uint8 // 4 byte with zeros
+}
+
+func (a *NXActionDecTTL) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionDecTTL) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.controllers)
+	n += 2
+	copy(data[n:], a.zeros[0:])
+	return
+}
+
+func (a *NXActionDecTTL) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the byte array has wrong size to unmarshal an NXActionRegLoad2 message")
+	}
+	a.controllers = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.zeros = [4]uint8{}
+	return err
+}
+
+func NewNXActionDecTTL() *NXActionDecTTL {
+	a := &NXActionDecTTL{
+		NXActionHeader: NewNxActionHeader(NXAST_DEC_TTL),
+		zeros:          [4]uint8{},
+	}
+	a.Length = 16
+	return a
+}
+
+type NXActionDecTTLCntIDs struct {
+	*NXActionHeader
+	controllers uint16   // number of controller
+	zeros       [4]uint8 // 4 byte with zeros
+	cntIDs      []uint16 // controller IDs
+}
+
+func (a *NXActionDecTTLCntIDs) Len() (n uint16) {
+	return a.Length
+}
+
+func (a *NXActionDecTTLCntIDs) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(a.Len()))
+	b := make([]byte, 0)
+	n := 0
+
+	b, err = a.NXActionHeader.MarshalBinary()
+	copy(data[n:], b)
+	n += len(b)
+	binary.BigEndian.PutUint16(data[n:], a.controllers)
+	n += 2
+	copy(data[n:], a.zeros[0:])
+	n += 4
+	for _, id := range a.cntIDs {
+		binary.BigEndian.PutUint16(data[n:], id)
+		n += 2
+	}
+	return
+}
+
+func (a *NXActionDecTTLCntIDs) UnmarshalBinary(data []byte) error {
+	n := 0
+	a.NXActionHeader = new(NXActionHeader)
+	err := a.NXActionHeader.UnmarshalBinary(data[n:])
+	n += int(a.NXActionHeader.Len())
+	if len(data) < int(a.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full NXActionDecTTLCntIDs message")
+	}
+	a.controllers = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	a.zeros = [4]uint8{}
+	n += 4
+	for i := 0; i < int(a.controllers); i++ {
+		id := binary.BigEndian.Uint16(data[n:])
+		a.cntIDs = append(a.cntIDs, id)
+		n += 2
+	}
+	return err
+}
+
+func NewNXActionDecTTLCntIDs(controllers uint16, ids ...uint16) *NXActionDecTTLCntIDs {
+	a := &NXActionDecTTLCntIDs{
+		NXActionHeader: NewNxActionHeader(NXAST_DEC_TTL_CNT_IDS),
+		controllers:    controllers,
+		zeros:          [4]uint8{},
+		cntIDs:         ids,
+	}
+	a.Length = 16 + uint16(2*len(ids))
+	return a
+}

--- a/openflow13/nx_match.go
+++ b/openflow13/nx_match.go
@@ -1,0 +1,269 @@
+package openflow13
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+)
+
+type Uint16Message struct {
+	data uint16
+}
+
+func newUint16Message(data uint16) *Uint16Message {
+	return &Uint16Message{data: data}
+}
+
+func (m *Uint16Message) Len() uint16 {
+	return 2
+}
+
+func (m *Uint16Message) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, m.Len())
+	binary.BigEndian.PutUint16(data, m.data)
+	return
+}
+
+func (m *Uint16Message) UnmarshalBinary(data []byte) error {
+	if len(data) < 2 {
+		return errors.New("the byte array has wrong size to unmarshal Uint16Message")
+	}
+	m.data = binary.BigEndian.Uint16(data[:2])
+	return nil
+}
+
+type Uint32Message struct {
+	data uint32
+}
+
+func newUint32Message(data uint32) *Uint32Message {
+	return &Uint32Message{data: data}
+}
+
+func (m *Uint32Message) Len() uint16 {
+	return 4
+}
+
+func (m *Uint32Message) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, m.Len())
+	binary.BigEndian.PutUint32(data, m.data)
+	return
+}
+
+func (m *Uint32Message) UnmarshalBinary(data []byte) error {
+	if len(data) < 4 {
+		return errors.New("the byte array has wrong size to unmarshal Uint16Message")
+	}
+	m.data = binary.BigEndian.Uint32(data[:4])
+	return nil
+}
+
+type CTStates struct {
+	data uint32
+	mask uint32
+}
+
+func NewCTStates() *CTStates {
+	return new(CTStates)
+}
+
+// ct_state = +new
+func (s *CTStates) SetNew() {
+	s.data |= 1 << 0
+	s.mask |= 1 << 0
+}
+
+// ct_state = -new
+func (s *CTStates) UnsetNew() {
+	s.data |= 0 << NX_CT_STATE_NEW_OFS
+	s.mask |= 1 << NX_CT_STATE_NEW_OFS
+}
+
+// ct_state = +est
+func (s *CTStates) SetEst() {
+	s.data |= 1 << NX_CT_STATE_EST_OFS
+	s.mask |= 1 << NX_CT_STATE_EST_OFS
+}
+
+// ct_state = -est
+func (s *CTStates) UnsetEst() {
+	s.data |= 0 << NX_CT_STATE_EST_OFS
+	s.mask |= 1 << NX_CT_STATE_EST_OFS
+}
+
+// ct_state = +rel
+func (s *CTStates) SetRel() {
+	s.data |= 1 << NX_CT_STATE_REL_OFS
+	s.mask |= 1 << NX_CT_STATE_REL_OFS
+}
+
+// ct_state = -rel
+func (s *CTStates) UnsetRel() {
+	s.data |= 0 << NX_CT_STATE_REL_OFS
+	s.mask |= 1 << NX_CT_STATE_REL_OFS
+}
+
+// ct_state = +rpl
+func (s *CTStates) SetRpl() {
+	s.data |= 1 << NX_CT_STATE_RPL_OFS
+	s.mask |= 1 << NX_CT_STATE_RPL_OFS
+}
+
+// ct_state = -rpl
+func (s *CTStates) UnsetRpl() {
+	s.data |= 0 << NX_CT_STATE_RPL_OFS
+	s.mask |= 1 << NX_CT_STATE_RPL_OFS
+}
+
+// ct_state = +inv
+func (s *CTStates) SetInv() {
+	s.data |= 1 << NX_CT_STATE_INV_OFS
+	s.mask |= 1 << NX_CT_STATE_INV_OFS
+}
+
+// ct_state = -inv
+func (s *CTStates) UnsetInv() {
+	s.data |= 0 << NX_CT_STATE_INV_OFS
+	s.mask |= 1 << NX_CT_STATE_INV_OFS
+}
+
+// ct_state = +trk
+func (s *CTStates) SetTrk() {
+	s.data |= 1 << NX_CT_STATE_TRK_OFS
+	s.mask |= 1 << NX_CT_STATE_TRK_OFS
+}
+
+// ct_state = -trk
+func (s *CTStates) UnsetTrk() {
+	s.data |= 0 << NX_CT_STATE_TRK_OFS
+	s.mask |= 1 << NX_CT_STATE_TRK_OFS
+}
+
+// ct_state = +snat
+func (s *CTStates) SetSNAT() {
+	s.data |= 1 << NX_CT_STATE_SNAT_OFS
+	s.mask |= 1 << NX_CT_STATE_SNAT_OFS
+}
+
+// ct_state = -snat
+func (s *CTStates) UnsetSNAT() {
+	s.data |= 0 << NX_CT_STATE_SNAT_OFS
+	s.mask |= 1 << NX_CT_STATE_SNAT_OFS
+}
+
+// ct_state = +dnat
+func (s *CTStates) SetDNAT() {
+	s.data |= 1 << NX_CT_STATE_DNAT_OFS
+	s.mask |= 1 << NX_CT_STATE_DNAT_OFS
+}
+
+// ct_state = -dnat
+func (s *CTStates) UnsetDNAT() {
+	s.data |= 0 << NX_CT_STATE_DNAT_OFS
+	s.mask |= 1 << NX_CT_STATE_DNAT_OFS
+}
+
+type NXRange struct {
+	start int
+	end   int
+}
+
+func newNXRegHeader(idx int, hasMask bool) *MatchField {
+	idKey := fmt.Sprintf("NXM_NX_REG%d", idx)
+	header, _ := FindFieldHeaderByName(idKey, hasMask)
+	return header
+}
+
+func NewRegMatchField(idx int, data uint32, dataRng *NXRange) *MatchField {
+	var field *MatchField
+	if dataRng != nil {
+		field = newNXRegHeader(idx, true)
+	} else {
+		field = newNXRegHeader(idx, false)
+	}
+
+	field.Value = newUint32Message(data)
+
+	if dataRng != nil {
+		field.Mask = newUint32Message(dataRng.ToUint32Mask())
+	}
+	return field
+}
+
+func NewCTStateMatchField(states *CTStates) *MatchField {
+	field, _ := FindFieldHeaderByName("NXM_NX_CT_STATE", true)
+	field.Value = newUint32Message(states.data)
+	field.Mask = newUint32Message(states.mask)
+	return field
+}
+
+func NewCTZoneMatchField(zone uint16) *MatchField {
+	field, _ := FindFieldHeaderByName("NXM_NX_CT_ZONE", false)
+	field.Value = newUint16Message(zone)
+	return field
+}
+
+func NewCTMarkMatchField(mark uint32, mask *uint32) *MatchField {
+	var field *MatchField
+	if mask != nil {
+		field, _ = FindFieldHeaderByName("NXM_NX_CT_MARK", true)
+		field.Mask = newUint32Message(*mask)
+	} else {
+		field, _ = FindFieldHeaderByName("NXM_NX_CT_MARK", false)
+	}
+	field.Value = newUint32Message(mark)
+
+	return field
+}
+
+type CTLabel struct {
+	data [16]byte
+}
+
+func (m *CTLabel) Len() uint16 {
+	return uint16(len(m.data))
+}
+
+func (m *CTLabel) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, m.Len())
+	copy(data, m.data[:])
+	err = nil
+	return
+}
+
+func (m *CTLabel) UnmarshalBinary(data []byte) error {
+	m.data = [16]byte{}
+	if len(data) < len(m.data) {
+		copy(m.data[:], data)
+	} else {
+		copy(m.data[:], data[:16])
+	}
+	return nil
+}
+
+func newCTLabel(data [16]byte) *CTLabel {
+	label := new(CTLabel)
+	_ = label.UnmarshalBinary(data[:16])
+	return label
+}
+
+func NewCTLabelMatchField(label [16]byte, mask *[16]byte) *MatchField {
+	var field *MatchField
+	if mask != nil {
+		field, _ = FindFieldHeaderByName("NXM_NX_CT_LABEL", true)
+		field.Mask = newCTLabel(*mask)
+	} else {
+		field, _ = FindFieldHeaderByName("NXM_NX_CT_LABEL", false)
+	}
+	field.Value = newCTLabel(label)
+
+	return field
+}
+
+func NewConjIDMatchField(conjID uint32) *MatchField {
+	field, _ := FindFieldHeaderByName("NXM_NX_CONJ_ID", false)
+	field.Value = newUint32Message(conjID)
+
+	return field
+}

--- a/openflow13/nx_match.go
+++ b/openflow13/nx_match.go
@@ -76,7 +76,7 @@ func (s *CTStates) SetNew() {
 
 // ct_state = -new
 func (s *CTStates) UnsetNew() {
-	s.data |= 0 << NX_CT_STATE_NEW_OFS
+	s.data &^= 1 << NX_CT_STATE_NEW_OFS
 	s.mask |= 1 << NX_CT_STATE_NEW_OFS
 }
 
@@ -88,7 +88,7 @@ func (s *CTStates) SetEst() {
 
 // ct_state = -est
 func (s *CTStates) UnsetEst() {
-	s.data |= 0 << NX_CT_STATE_EST_OFS
+	s.data &^= 1 << NX_CT_STATE_EST_OFS
 	s.mask |= 1 << NX_CT_STATE_EST_OFS
 }
 
@@ -100,7 +100,7 @@ func (s *CTStates) SetRel() {
 
 // ct_state = -rel
 func (s *CTStates) UnsetRel() {
-	s.data |= 0 << NX_CT_STATE_REL_OFS
+	s.data &^= 1 << NX_CT_STATE_REL_OFS
 	s.mask |= 1 << NX_CT_STATE_REL_OFS
 }
 
@@ -112,7 +112,7 @@ func (s *CTStates) SetRpl() {
 
 // ct_state = -rpl
 func (s *CTStates) UnsetRpl() {
-	s.data |= 0 << NX_CT_STATE_RPL_OFS
+	s.data &^= 1 << NX_CT_STATE_RPL_OFS
 	s.mask |= 1 << NX_CT_STATE_RPL_OFS
 }
 
@@ -124,7 +124,7 @@ func (s *CTStates) SetInv() {
 
 // ct_state = -inv
 func (s *CTStates) UnsetInv() {
-	s.data |= 0 << NX_CT_STATE_INV_OFS
+	s.data &^= 1 << NX_CT_STATE_INV_OFS
 	s.mask |= 1 << NX_CT_STATE_INV_OFS
 }
 
@@ -136,7 +136,7 @@ func (s *CTStates) SetTrk() {
 
 // ct_state = -trk
 func (s *CTStates) UnsetTrk() {
-	s.data |= 0 << NX_CT_STATE_TRK_OFS
+	s.data &^= 1 << NX_CT_STATE_TRK_OFS
 	s.mask |= 1 << NX_CT_STATE_TRK_OFS
 }
 
@@ -148,7 +148,7 @@ func (s *CTStates) SetSNAT() {
 
 // ct_state = -snat
 func (s *CTStates) UnsetSNAT() {
-	s.data |= 0 << NX_CT_STATE_SNAT_OFS
+	s.data &^= 1 << NX_CT_STATE_SNAT_OFS
 	s.mask |= 1 << NX_CT_STATE_SNAT_OFS
 }
 
@@ -160,7 +160,7 @@ func (s *CTStates) SetDNAT() {
 
 // ct_state = -dnat
 func (s *CTStates) UnsetDNAT() {
-	s.data |= 0 << NX_CT_STATE_DNAT_OFS
+	s.data &^= 1 << NX_CT_STATE_DNAT_OFS
 	s.mask |= 1 << NX_CT_STATE_DNAT_OFS
 }
 

--- a/openflow13/nx_match.go
+++ b/openflow13/nx_match.go
@@ -267,3 +267,67 @@ func NewConjIDMatchField(conjID uint32) *MatchField {
 
 	return field
 }
+
+func NewNxARPShaMatchField(addr net.HardwareAddr, mask net.HardwareAddr) *MatchField {
+	var field *MatchField
+	if mask != nil {
+		field, _ = FindFieldHeaderByName("NXM_NX_ARP_SHA", true)
+	} else {
+		field, _ = FindFieldHeaderByName("NXM_NX_ARP_SHA", false)
+	}
+
+	field.Value = &ArpXHaField{arpHa: addr}
+	if mask != nil {
+		field.Mask = &ArpXHaField{arpHa: mask}
+	}
+
+	return field
+}
+
+func NewNxARPThaMatchField(addr net.HardwareAddr, mask net.HardwareAddr) *MatchField {
+	var field *MatchField
+	if mask != nil {
+		field, _ = FindFieldHeaderByName("NXM_NX_ARP_THA", true)
+	} else {
+		field, _ = FindFieldHeaderByName("NXM_NX_ARP_THA", false)
+	}
+
+	field.Value = &ArpXHaField{arpHa: addr}
+	if mask != nil {
+		field.Mask = &ArpXHaField{arpHa: mask}
+	}
+
+	return field
+}
+
+func NewNxARPSpaMatchField(addr net.IP, mask net.IP) *MatchField {
+	var field *MatchField
+	if mask != nil {
+		field, _ = FindFieldHeaderByName("NXM_OF_ARP_SPA", true)
+	} else {
+		field, _ = FindFieldHeaderByName("NXM_OF_ARP_SPA", false)
+	}
+
+	field.Value = &ArpXPaField{ArpPa: addr}
+	if mask != nil {
+		field.Mask = &ArpXPaField{ArpPa: mask}
+	}
+
+	return field
+}
+
+func NewNxARPTpaMatchField(addr net.IP, mask net.IP) *MatchField {
+	var field *MatchField
+	if mask != nil {
+		field, _ = FindFieldHeaderByName("NXM_OF_ARP_TPA", true)
+	} else {
+		field, _ = FindFieldHeaderByName("NXM_OF_ARP_TPA", false)
+	}
+
+	field.Value = &ArpXPaField{ArpPa: addr}
+	if mask != nil {
+		field.Mask = &ArpXPaField{ArpPa: mask}
+	}
+
+	return field
+}

--- a/openflow13/nx_match.go
+++ b/openflow13/nx_match.go
@@ -27,7 +27,7 @@ func (m *Uint16Message) MarshalBinary() (data []byte, err error) {
 
 func (m *Uint16Message) UnmarshalBinary(data []byte) error {
 	if len(data) < 2 {
-		return errors.New("the byte array has wrong size to unmarshal Uint16Message")
+		return errors.New("the []byte is too short to unmarshal a full Uint16Message")
 	}
 	m.data = binary.BigEndian.Uint16(data[:2])
 	return nil
@@ -53,7 +53,7 @@ func (m *Uint32Message) MarshalBinary() (data []byte, err error) {
 
 func (m *Uint32Message) UnmarshalBinary(data []byte) error {
 	if len(data) < 4 {
-		return errors.New("the byte array has wrong size to unmarshal Uint16Message")
+		return errors.New("the []byte is too short to unmarshal a full Uint32Message")
 	}
 	m.data = binary.BigEndian.Uint32(data[:4])
 	return nil
@@ -68,97 +68,97 @@ func NewCTStates() *CTStates {
 	return new(CTStates)
 }
 
-// ct_state = +new
+// SetNew sets ct_state as "+new".
 func (s *CTStates) SetNew() {
 	s.data |= 1 << 0
 	s.mask |= 1 << 0
 }
 
-// ct_state = -new
+// UnsetNew sets ct_state as "-new".
 func (s *CTStates) UnsetNew() {
 	s.data &^= 1 << NX_CT_STATE_NEW_OFS
 	s.mask |= 1 << NX_CT_STATE_NEW_OFS
 }
 
-// ct_state = +est
+// SetEst sets ct_state as "+est".
 func (s *CTStates) SetEst() {
 	s.data |= 1 << NX_CT_STATE_EST_OFS
 	s.mask |= 1 << NX_CT_STATE_EST_OFS
 }
 
-// ct_state = -est
+// UnsetEst sets ct_state as "-est".
 func (s *CTStates) UnsetEst() {
 	s.data &^= 1 << NX_CT_STATE_EST_OFS
 	s.mask |= 1 << NX_CT_STATE_EST_OFS
 }
 
-// ct_state = +rel
+// SetRel sets ct_state as "+rel".
 func (s *CTStates) SetRel() {
 	s.data |= 1 << NX_CT_STATE_REL_OFS
 	s.mask |= 1 << NX_CT_STATE_REL_OFS
 }
 
-// ct_state = -rel
+// UnsetRel sets ct_state as "-rel".
 func (s *CTStates) UnsetRel() {
 	s.data &^= 1 << NX_CT_STATE_REL_OFS
 	s.mask |= 1 << NX_CT_STATE_REL_OFS
 }
 
-// ct_state = +rpl
+// SetRpl sets ct_state as "+rpl".
 func (s *CTStates) SetRpl() {
 	s.data |= 1 << NX_CT_STATE_RPL_OFS
 	s.mask |= 1 << NX_CT_STATE_RPL_OFS
 }
 
-// ct_state = -rpl
+// UnsetRpl sets ct_state as "-rpl".
 func (s *CTStates) UnsetRpl() {
 	s.data &^= 1 << NX_CT_STATE_RPL_OFS
 	s.mask |= 1 << NX_CT_STATE_RPL_OFS
 }
 
-// ct_state = +inv
+// SetInv sets ct_state as "+inv".
 func (s *CTStates) SetInv() {
 	s.data |= 1 << NX_CT_STATE_INV_OFS
 	s.mask |= 1 << NX_CT_STATE_INV_OFS
 }
 
-// ct_state = -inv
+// UnsetInv sets ct_state as "-inv".
 func (s *CTStates) UnsetInv() {
 	s.data &^= 1 << NX_CT_STATE_INV_OFS
 	s.mask |= 1 << NX_CT_STATE_INV_OFS
 }
 
-// ct_state = +trk
+// SetTrk sets ct_state as "+trk".
 func (s *CTStates) SetTrk() {
 	s.data |= 1 << NX_CT_STATE_TRK_OFS
 	s.mask |= 1 << NX_CT_STATE_TRK_OFS
 }
 
-// ct_state = -trk
+// UnsetTrk sets ct_state as "-trk".
 func (s *CTStates) UnsetTrk() {
 	s.data &^= 1 << NX_CT_STATE_TRK_OFS
 	s.mask |= 1 << NX_CT_STATE_TRK_OFS
 }
 
-// ct_state = +snat
+// SetSNAT sets ct_state as "+snat".
 func (s *CTStates) SetSNAT() {
 	s.data |= 1 << NX_CT_STATE_SNAT_OFS
 	s.mask |= 1 << NX_CT_STATE_SNAT_OFS
 }
 
-// ct_state = -snat
+// UnsetSNAT sets ct_state as "-snat".
 func (s *CTStates) UnsetSNAT() {
 	s.data &^= 1 << NX_CT_STATE_SNAT_OFS
 	s.mask |= 1 << NX_CT_STATE_SNAT_OFS
 }
 
-// ct_state = +dnat
+// SetDNAT sets ct_state as "+dnat".
 func (s *CTStates) SetDNAT() {
 	s.data |= 1 << NX_CT_STATE_DNAT_OFS
 	s.mask |= 1 << NX_CT_STATE_DNAT_OFS
 }
 
-// ct_state = -dnat
+// UnsetDNAT sets ct_state as "-dnat".
 func (s *CTStates) UnsetDNAT() {
 	s.data &^= 1 << NX_CT_STATE_DNAT_OFS
 	s.mask |= 1 << NX_CT_STATE_DNAT_OFS

--- a/openflow13/nx_util.go
+++ b/openflow13/nx_util.go
@@ -6,6 +6,7 @@ import (
 )
 
 const (
+	// OFPP_IN_PORT is the default number of in_port field in resubmit actions.
 	OFPP_IN_PORT = 0xfff8
 )
 
@@ -28,7 +29,7 @@ const (
 	NX_CT_RECIRC_NONE = 0xff
 )
 
-// NX_NAT_RANGE Flags
+// NX_NAT_RANGE flags
 const (
 	NX_NAT_RANGE_IPV4_MIN  = 1 << 0
 	NX_NAT_RANGE_IPV4_MAX  = 1 << 1
@@ -38,6 +39,7 @@ const (
 	NX_NAT_RANGE_PROTO_MAX = 1 << 5
 )
 
+// NX_NAT flags
 const (
 	NX_NAT_F_SRC          = 1 << 0
 	NX_NAT_F_DST          = 1 << 1
@@ -47,6 +49,7 @@ const (
 	NX_NAT_F_MASK         = (NX_NAT_F_SRC | NX_NAT_F_DST | NX_NAT_F_PERSISTENT | NX_NAT_F_PROTO_HASH | NX_NAT_F_PROTO_RANDOM)
 )
 
+// NXM_OF fields. The class number of thses fields are 0x0000.
 const (
 	NXM_OF_IN_PORT uint8 = iota
 	NXM_OF_ETH_DST
@@ -206,8 +209,8 @@ func init() {
 	}
 }
 
+// FindFieldHeaderByName finds OXM/NXM field by name and mask.
 func FindFieldHeaderByName(fieldName string, hasMask bool) (*MatchField, error) {
-	var err = fmt.Errorf("failed to find header by name %s", fieldName)
 	fieldKey := strings.ToUpper(fieldName)
 	var fieldsMap map[string]*MatchField
 	if hasMask {
@@ -217,19 +220,19 @@ func FindFieldHeaderByName(fieldName string, hasMask bool) (*MatchField, error) 
 	}
 	field, found := fieldsMap[fieldKey]
 	if !found {
-		return nil, err
+		return nil, fmt.Errorf("failed to find header by name %s", fieldName)
 	}
 
 	return field, nil
 }
 
-// Encode the range to a uint16 number
+// encodeOfsNbitsStartEnd encodes the range to a uint16 number.
 func encodeOfsNbitsStartEnd(start uint16, end uint16) uint16 {
 	return (start << 6) + (end - start)
 }
 
-// Encode the range to a uint16 number
-// ofs is the start pos, nBits is the count of the range
+// Encode the range to a uint16 number.
+// ofs is the start pos, nBits is the count of the range.
 func encodeOfsNbits(ofs uint16, nBits uint16) uint16 {
 	return ofs<<6 | (nBits - 1)
 }
@@ -242,14 +245,17 @@ func decodeNbits(ofsBnits uint16) uint16 {
 	return (ofsBnits & 0x3f) + 1
 }
 
+// NewNXRange creates a NXRange using start and end number.
 func NewNXRange(start int, end int) *NXRange {
 	return &NXRange{start: start, end: end}
 }
 
+// NewNXRangeByOfsNBits creates a NXRange using offshift and bit count.
 func NewNXRangeByOfsNBits(ofs int, nBits int) *NXRange {
 	return &NXRange{start: ofs, end: ofs + nBits - 1}
 }
 
+// ToUint32Mask generates a uint32 number mask from NXRange.
 func (n *NXRange) ToUint32Mask() uint32 {
 	start := n.start
 	maxLength := 32
@@ -265,14 +271,17 @@ func (n *NXRange) ToUint32Mask() uint32 {
 	return mask1
 }
 
+// ToOfsBits encodes the NXRange to a uint16 number to identify offshift and bits count.
 func (n *NXRange) ToOfsBits() uint16 {
 	return encodeOfsNbitsStartEnd(uint16(n.start), uint16(n.end))
 }
 
+// GetOfs returns the offshift number from NXRange.
 func (n *NXRange) GetOfs() uint16 {
 	return uint16(n.start)
 }
 
+// GetNbits returns the bits count from NXRange.
 func (n *NXRange) GetNbits() uint16 {
 	return uint16(n.end - n.start + 1)
 }

--- a/openflow13/nx_util.go
+++ b/openflow13/nx_util.go
@@ -1,0 +1,278 @@
+package openflow13
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	OFPP_IN_PORT = 0xfff8
+)
+
+// NX_CT_STATES
+const (
+	NX_CT_STATE_NEW_OFS  = 0
+	NX_CT_STATE_EST_OFS  = 1
+	NX_CT_STATE_REL_OFS  = 2
+	NX_CT_STATE_RPL_OFS  = 3
+	NX_CT_STATE_INV_OFS  = 4
+	NX_CT_STATE_TRK_OFS  = 5
+	NX_CT_STATE_SNAT_OFS = 6
+	NX_CT_STATE_DNAT_OFS = 7
+)
+
+// NX_CT Flags
+const (
+	NX_CT_F_COMMIT    = 1 << 0
+	NX_CT_F_FORCE     = 1 << 1
+	NX_CT_RECIRC_NONE = 0xff
+)
+
+// NX_NAT_RANGE Flags
+const (
+	NX_NAT_RANGE_IPV4_MIN  = 1 << 0
+	NX_NAT_RANGE_IPV4_MAX  = 1 << 1
+	NX_NAT_RANGE_IPV6_MIN  = 1 << 2
+	NX_NAT_RANGE_IPV6_MAX  = 1 << 3
+	NX_NAT_RANGE_PROTO_MIN = 1 << 4
+	NX_NAT_RANGE_PROTO_MAX = 1 << 5
+)
+
+const (
+	NX_NAT_F_SRC          = 1 << 0
+	NX_NAT_F_DST          = 1 << 1
+	NX_NAT_F_PERSISTENT   = 1 << 2
+	NX_NAT_F_PROTO_HASH   = 1 << 3
+	NX_NAT_F_PROTO_RANDOM = 1 << 4
+	NX_NAT_F_MASK         = (NX_NAT_F_SRC | NX_NAT_F_DST | NX_NAT_F_PERSISTENT | NX_NAT_F_PROTO_HASH | NX_NAT_F_PROTO_RANDOM)
+)
+
+const (
+	NXM_OF_IN_PORT uint8 = iota
+	NXM_OF_ETH_DST
+	NXM_OF_ETH_SRC
+	NXM_OF_ETH_TYPE
+	NXM_OF_VLAN_TCI
+	NXM_OF_IP_TOS
+	NXM_OF_IP_PROTO
+	NXM_OF_IP_SRC
+	NXM_OF_IP_DST
+	NXM_OF_TCP_SRC
+	NXM_OF_TCP_DST
+	NXM_OF_UDP_SRC
+	NXM_OF_UDP_DST
+	NXM_OF_ICMP_TYPE
+	NXM_OF_ICMP_CODE
+	NXM_OF_ARP_OP
+	NXM_OF_ARP_SPA
+	NXM_OF_ARP_TPA
+)
+
+func newMatchFieldHeader(class uint16, field uint8, length uint8) *MatchField {
+	var fieldLength = length
+	return &MatchField{Class: class, Field: field, Length: fieldLength, HasMask: false}
+}
+
+// oxxFieldHeaderMap is map to find target field header without mask using an OVS known OXX field name
+var oxxFieldHeaderMap = map[string]*MatchField{
+	"NXM_OF_IN_PORT":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IN_PORT, 2),
+	"NXM_OF_ETH_DST":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ETH_DST, 6),
+	"NXM_OF_ETH_SRC":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ETH_SRC, 6),
+	"NXM_OF_ETH_TYPE":  newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ETH_TYPE, 2),
+	"NXM_OF_VLAN_TCI":  newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_VLAN_TCI, 2),
+	"NXM_OF_IP_TOS":    newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IP_TOS, 1),
+	"NXM_OF_IP_PROTO":  newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IP_PROTO, 1),
+	"NXM_OF_IP_SRC":    newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IP_SRC, 4),
+	"NXM_OF_IP_DST":    newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_IP_DST, 4),
+	"NXM_OF_TCP_SRC":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_TCP_SRC, 2),
+	"NXM_OF_TCP_DST":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_TCP_DST, 2),
+	"NXM_OF_UDP_SRC":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_UDP_SRC, 2),
+	"NXM_OF_UDP_DST":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_UDP_DST, 2),
+	"NXM_OF_ICMP_TYPE": newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ICMP_TYPE, 1),
+	"NXM_OF_ICMP_CODE": newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ICMP_CODE, 1),
+	"NXM_OF_ARP_OP":    newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ARP_OP, 2),
+	"NXM_OF_ARP_SPA":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ARP_SPA, 4),
+	"NXM_OF_ARP_TPA":   newMatchFieldHeader(OXM_CLASS_NXM_0, NXM_OF_ARP_TPA, 4),
+
+	"NXM_NX_REG0":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG0, 4),
+	"NXM_NX_REG1":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG1, 4),
+	"NXM_NX_REG2":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG2, 4),
+	"NXM_NX_REG3":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG3, 4),
+	"NXM_NX_REG4":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG4, 4),
+	"NXM_NX_REG5":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG5, 4),
+	"NXM_NX_REG6":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG6, 4),
+	"NXM_NX_REG7":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG7, 4),
+	"NXM_NX_REG8":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG8, 4),
+	"NXM_NX_REG9":          newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG9, 4),
+	"NXM_NX_REG10":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG10, 4),
+	"NXM_NX_REG11":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG11, 4),
+	"NXM_NX_REG12":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG12, 4),
+	"NXM_NX_REG13":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG13, 4),
+	"NXM_NX_REG14":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG14, 4),
+	"NXM_NX_REG15":         newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_REG15, 4),
+	"NXM_NX_TUN_ID":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_ID, 8),
+	"NXM_NX_ARP_SHA":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ARP_SHA, 6),
+	"NXM_NX_ARP_THA":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ARP_THA, 6),
+	"NXM_NX_IPV6_SRC":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IPV6_SRC, 16),
+	"NXM_NX_IPV6_DST":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IPV6_DST, 16),
+	"NXM_NX_ICMPV6_TYPE":   newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ICMPV6_TYPE, 1),
+	"NXM_NX_ICMPV6_CODE":   newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ICMPV6_CODE, 1),
+	"NXM_NX_ND_TARGET":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ND_TARGET, 16),
+	"NXM_NX_ND_SLL":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ND_SLL, 6),
+	"NXM_NX_ND_TLL":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_ND_TLL, 6),
+	"NXM_NX_IP_FRAG":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IP_FRAG, 1),
+	"NXM_NX_IPV6_LABEL":    newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IPV6_LABEL, 1),
+	"NXM_NX_IP_ECN":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IP_ECN, 1),
+	"NXM_NX_IP_TTL":        newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_IP_TTL, 1),
+	"NXM_NX_MPLS_TTL":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_MPLS_TTL, 1),
+	"NXM_NX_TUN_IPV4_SRC":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV4_SRC, 4),
+	"NXM_NX_TUN_IPV4_DST":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV4_DST, 4),
+	"NXM_NX_PKT_MARK":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_PKT_MARK, 4),
+	"NXM_NX_TCP_FLAGS":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TCP_FLAGS, 2),
+	"NXM_NX_CONJ_ID":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CONJ_ID, 4),
+	"NXM_NX_TUN_GBP_ID":    newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_GBP_ID, 2),
+	"NXM_NX_TUN_GBP_FLAGS": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_GBP_FLAGS, 1),
+	"NXM_NX_TUN_FLAGS":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_FLAGS, 2),
+	"NXM_NX_CT_STATE":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_STATE, 4),
+	"NXM_NX_CT_ZONE":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_ZONE, 2),
+	"NXM_NX_CT_MARK":       newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_MARK, 4),
+	"NXM_NX_CT_LABEL":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_LABEL, 16),
+	"NXM_NX_TUN_IPV6_SRC":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV6_SRC, 16),
+	"NXM_NX_TUN_IPV6_DST":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV6_DST, 16),
+	"NXM_NX_TUN_METADATA0": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT0, 128),
+	"NXM_NX_TUN_METADATA1": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT1, 128),
+	"NXM_NX_TUN_METADATA2": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT2, 128),
+	"NXM_NX_TUN_METADATA3": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT3, 128),
+	"NXM_NX_TUN_METADATA4": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT4, 128),
+	"NXM_NX_TUN_METADATA5": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT5, 128),
+	"NXM_NX_TUN_METADATA6": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT6, 128),
+	"NXM_NX_TUN_METADATA7": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT7, 128),
+
+	"OXM_OF_IN_PORT":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IN_PORT, 4),
+	"OXM_OF_IN_PHY_PORT":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IN_PHY_PORT, 4),
+	"OXM_OF_METADATA":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_METADATA, 8),
+	"OXM_OF_ETH_DST":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ETH_DST, 6),
+	"OXM_OF_ETH_SRC":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ETH_SRC, 6),
+	"OXM_OF_ETH_TYPE":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ETH_TYPE, 2),
+	"OXM_OF_VLAN_VID":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_VLAN_VID, 2),
+	"OXM_OF_VLAN_PCP":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_VLAN_PCP, 1),
+	"OXM_OF_IP_DSCP":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IP_DSCP, 1),
+	"OXM_OF_IP_ECN":         newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IP_ECN, 1),
+	"OXM_OF_IP_PROTO":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IP_PROTO, 1),
+	"OXM_OF_IPV4_SRC":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV4_SRC, 4),
+	"OXM_OF_IPV4_DST":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV4_DST, 4),
+	"OXM_OF_TCP_SRC":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_TCP_SRC, 2),
+	"OXM_OF_TCP_DST":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_TCP_DST, 2),
+	"OXM_OF_UDP_SRC":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_UDP_SRC, 2),
+	"OXM_OF_UDP_DST":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_UDP_DST, 2),
+	"OXM_OF_SCTP_SRC":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_SCTP_SRC, 2),
+	"OXM_OF_SCTP_DST":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_SCTP_DST, 2),
+	"OXM_OF_ICMPV4_TYPE":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ICMPV4_TYPE, 1),
+	"OXM_OF_ICMPV4_CODE":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ICMPV4_CODE, 1),
+	"OXM_OF_ARP_OP":         newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_OP, 2),
+	"OXM_OF_ARP_SPA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_SPA, 4),
+	"OXM_OF_ARP_TPA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_TPA, 4),
+	"OXM_OF_ARP_SHA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_SHA, 6),
+	"OXM_OF_ARP_THA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_SHA, 6),
+	"OXM_OF_IPV6_SRC":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_SRC, 16),
+	"OXM_OF_IPV6_DST":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_DST, 16),
+	"OXM_OF_IPV6_FLABEL":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_FLABEL, 4),
+	"OXM_OF_ICMPV6_TYPE":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ICMPV6_TYPE, 1),
+	"OXM_OF_ICMPV6_CODE":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ICMPV6_CODE, 1),
+	"OXM_OF_IPV6_ND_TARGET": newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_ND_TARGET, 16),
+	"OXM_OF_IPV6_ND_SLL":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_ND_SLL, 6),
+	"OXM_OF_IPV6_ND_TLL":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_ND_TLL, 6),
+	"OXM_OF_MPLS_LABEL":     newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_MPLS_LABEL, 4),
+	"OXM_OF_MPLS_TC":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_MPLS_TC, 1),
+	"OXM_OF_MPLS_BOS":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_MPLS_BOS, 1),
+	"OXM_OF_PBB_ISID":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_PBB_ISID, 3),
+	"OXM_OF_TUNNEL_ID":      newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_TUNNEL_ID, 8),
+	"OXM_OF_IPV6_EXTHDR":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_EXTHDR, 2),
+}
+
+// oxxFieldHeaderWildMap is map to find target field header with mask using an OVS known OXX field name
+var oxxFieldHeaderWildMap map[string]*MatchField
+
+func init() {
+	oxxFieldHeaderWildMap = make(map[string]*MatchField)
+	for k, v := range oxxFieldHeaderMap {
+		field := &MatchField{
+			Class:   v.Class,
+			Field:   v.Field,
+			HasMask: true,
+			Length:  v.Length * 2,
+		}
+		oxxFieldHeaderWildMap[k] = field
+	}
+}
+
+func FindFieldHeaderByName(fieldName string, hasMask bool) (*MatchField, error) {
+	var err = fmt.Errorf("failed to find header by name %s", fieldName)
+	fieldKey := strings.ToUpper(fieldName)
+	var fieldsMap map[string]*MatchField
+	if hasMask {
+		fieldsMap = oxxFieldHeaderWildMap
+	} else {
+		fieldsMap = oxxFieldHeaderMap
+	}
+	field, found := fieldsMap[fieldKey]
+	if !found {
+		return nil, err
+	}
+
+	return field, nil
+}
+
+// Encode the range to a uint16 number
+func encodeOfsNbitsStartEnd(start uint16, end uint16) uint16 {
+	return (start << 6) + (end - start)
+}
+
+// Encode the range to a uint16 number
+// ofs is the start pos, nBits is the count of the range
+func encodeOfsNbits(ofs uint16, nBits uint16) uint16 {
+	return ofs<<6 | (nBits - 1)
+}
+
+func encodeOfs(ofsNbits uint16) uint16 {
+	return ofsNbits >> 6
+}
+
+func decodeNbits(ofsBnits uint16) uint16 {
+	return (ofsBnits & 0x3f) + 1
+}
+
+func NewNXRange(start int, end int) *NXRange {
+	return &NXRange{start: start, end: end}
+}
+
+func NewNXRangeByOfsNBits(ofs int, nBits int) *NXRange {
+	return &NXRange{start: ofs, end: ofs + nBits - 1}
+}
+
+func (n *NXRange) ToUint32Mask() uint32 {
+	start := n.start
+	maxLength := 32
+	var end int
+	if n.end != 0 {
+		end = n.end
+	} else {
+		end = maxLength
+	}
+	mask1 := ^uint32(0)
+	mask1 = mask1 >> uint32(maxLength-(end-n.start+1))
+	mask1 = mask1 << uint32(start)
+	return mask1
+}
+
+func (n *NXRange) ToOfsBits() uint16 {
+	return encodeOfsNbitsStartEnd(uint16(n.start), uint16(n.end))
+}
+
+func (n *NXRange) GetOfs() uint16 {
+	return uint16(n.start)
+}
+
+func (n *NXRange) GetNbits() uint16 {
+	return uint16(n.end - n.start + 1)
+}

--- a/openflow13/nxext_test.go
+++ b/openflow13/nxext_test.go
@@ -1,0 +1,376 @@
+package openflow13
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+func TestNXActionResubmit(t *testing.T) {
+	tableID := uint8(10)
+	portID := uint16(10)
+
+	action1 := NewNXActionResubmit(portID)
+	data1, err := action1.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary: %v", err)
+	}
+	testAction1 := new(NXActionResubmitTable)
+	testAction1.UnmarshalBinary(data1)
+	if testAction1.InPort != portID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.UnmarshalBinary, expect: %x, actual: %x", portID, testAction1.InPort)
+	}
+
+	action2 := NewNXActionResubmitTableAction(portID, tableID)
+	if action2.Length != 16 {
+		t.Errorf("Failed to create action2 NXAST_RESUBMIT_TABLE")
+	}
+	data2, err := action2.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary: %v", err)
+	}
+	testAction2 := newNXActionResubmitTable()
+	testAction2.UnmarshalBinary(data2)
+	if testAction2.TableID != tableID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.UnmarshalBinary, expect: %x, actual: %x", tableID, testAction2.TableID)
+	}
+	if testAction2.InPort != portID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.UnmarshalBinary, expect: %x, actual: %x", portID, testAction2.InPort)
+	}
+
+	action3 := NewNXActionResubmitTableAction(OFPP_IN_PORT, tableID)
+	if action3.Length != 16 {
+		t.Errorf("Failed to create action2 NXAST_RESUBMIT_TABLE")
+	}
+	data3, err := action3.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary: %v", err)
+	}
+	testAction3 := newNXActionResubmitTable()
+	testAction3.UnmarshalBinary(data3)
+	if testAction3.TableID != tableID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.UnmarshalBinary, expect: %x, actual: %x", tableID, testAction3.TableID)
+	}
+	if testAction3.InPort != OFPP_IN_PORT {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.UnmarshalBinary, expect: %x, actual: %x", portID, testAction3.InPort)
+	}
+
+	action4 := NewNXActionResubmitTableCT(portID, tableID)
+	data4, err := action4.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary: %v", err)
+	}
+	testAction4 := newNXActionResubmitTableCT()
+	testAction4.UnmarshalBinary(data4)
+	if !testAction4.IsCT() {
+		t.Error("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary")
+	}
+	if testAction4.TableID != tableID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE_CT.UnmarshalBinary, expect: %x, actual: %x", tableID, testAction4.TableID)
+	}
+	if testAction4.InPort != portID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE_CT.UnmarshalBinary, expect: %x, actual: %x", portID, testAction4.InPort)
+	}
+
+	action5 := NewNXActionResubmitTableCTNoInPort(tableID)
+	data5, err := action5.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary: %v", err)
+	}
+	testAction5 := newNXActionResubmitTableCT()
+	if !testAction5.IsCT() {
+		t.Error("Failed to invoke NXAST_RESUBMIT_TABLE.MarshalBinary")
+	}
+	testAction5.UnmarshalBinary(data5)
+	if testAction5.TableID != tableID {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE_CT.UnmarshalBinary, expect: %x, actual: %x", tableID, testAction5.TableID)
+	}
+	if testAction5.InPort != OFPP_IN_PORT {
+		t.Errorf("Failed to invoke NXAST_RESUBMIT_TABLE_CT.UnmarshalBinary, expect: %x, actual: %x", portID, testAction5.InPort)
+	}
+}
+
+func TestNOfs(t *testing.T) {
+	var start, ofs, end, nBits uint16
+	start = uint16(16)
+	ofs = uint16(16)
+	nBits = uint16(16)
+	end = uint16(31)
+
+	encodeStartEnd := encodeOfsNbitsStartEnd(start, end)
+	encodeOfsNbits := encodeOfsNbits(ofs, nBits)
+	decodeOfs := encodeOfs(encodeOfsNbits)
+	deCodeNbits := decodeNbits(encodeOfsNbits)
+
+	if encodeStartEnd != encodeOfsNbits {
+		t.Errorf("Failed to encode from start to end, expect: %d, actual: %d", encodeOfsNbits, encodeStartEnd)
+	}
+	if ofs != decodeOfs {
+		t.Errorf("Failed to decode ofs, expect: %d, actual: %d", ofs, decodeOfs)
+	}
+	if nBits != deCodeNbits {
+		t.Errorf("Failed to decode nBits, expect: %d, actual: %d", nBits, deCodeNbits)
+	}
+}
+
+func TestUint32Message(t *testing.T) {
+	tgtData := uint32(0xff00ff00)
+	msg := newUint32Message(tgtData)
+	if msg.Len() != 4 {
+		t.Errorf("Failed to generate Uint32Message")
+	}
+	testData, err := msg.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to invoke Uint32Message.MarshalBinary, %v", err)
+	}
+	var testMsg = new(Uint32Message)
+	err = testMsg.UnmarshalBinary(testData)
+	if err != nil {
+		t.Errorf("Failed to invoke Uint32Message.UnmarshalBinary, %v", err)
+	}
+	if testMsg.data != tgtData {
+		t.Errorf("Failed to recover uint32 from Uint32Message, tgt: %d, actual: %d", tgtData, testMsg.data)
+	}
+}
+
+func TestUint16Message(t *testing.T) {
+	tgtData := uint16(0xfe10)
+	msg := newUint16Message(tgtData)
+	if msg.Len() != 2 {
+		t.Errorf("Failed to generate Uint32Message")
+	}
+	testData, err := msg.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to invoke Uint32Message.MarshalBinary, %v", err)
+	}
+	var testMsg = new(Uint16Message)
+	err = testMsg.UnmarshalBinary(testData)
+	if err != nil {
+		t.Errorf("Failed to invoke Uint32Message.UnmarshalBinary, %v", err)
+	}
+	if testMsg.data != tgtData {
+		t.Errorf("Failed to recover uint32 from Uint32Message, tgt: %d, actual: %d", tgtData, testMsg.data)
+	}
+}
+
+func TestNewUintXMask(t *testing.T) {
+	tgtData32 := uint32(0xff)
+	rng1 := &NXRange{start: 0, end: 7}
+	testMsg := &Uint32Message{data: rng1.ToUint32Mask()}
+	if testMsg.data != tgtData32 {
+		t.Errorf("Failed to invoke newUint32Mask, expected: %02x, actual: %02x", tgtData32, testMsg.data)
+	}
+}
+
+func TestNXMFieldHeader(t *testing.T) {
+	for k := range oxxFieldHeaderMap {
+		field1, err := FindFieldHeaderByName(k, false)
+		if err != nil {
+			t.Errorf("Test failed: %v", err)
+		}
+		testMatchFieldHeaderMarshalUnMarshal(field1, t)
+		field2, _ := FindFieldHeaderByName(k, true)
+		testMatchFieldHeaderMarshalUnMarshal(field2, t)
+	}
+}
+
+func TestCTLabel(t *testing.T) {
+	var label = [16]byte{}
+	testData, err := hex.DecodeString(fmt.Sprintf("%d", 0x12345678))
+	copy(label[:], testData)
+	field := newCTLabel(label)
+	data, err := field.MarshalBinary()
+	if err != nil {
+		t.Errorf("Failed to MarshalBinary CTLabel: %v", err)
+	}
+	field2 := new(CTLabel)
+	field2.UnmarshalBinary(data)
+	if field2.data != label {
+		t.Errorf("Failed to UnmarshalBinary CTLabel: %v", err)
+	}
+
+	var mask = [16]byte{}
+	binary.BigEndian.PutUint32(mask[:], 0xffffffff)
+}
+
+func TestNXActions(t *testing.T) {
+	translateMessages(t, NewNXActionConjunction(uint8(1), uint8(3), uint32(0xffee)), new(NXActionConjunction), nxConjunctionEquals)
+
+	dstField, _ := FindFieldHeaderByName("NXM_NX_REG0", false)
+	loadData := uint64(0xf009)
+	translateMessages(t, NewNXActionRegLoad(NewNXRange(0, 31).ToOfsBits(), dstField, loadData), new(NXActionRegLoad), nxRegLoadEquals)
+
+	moveSrc, _ := FindFieldHeaderByName("NXM_OF_ETH_SRC", false)
+	moveDst, _ := FindFieldHeaderByName("NXM_OF_ETH_DST", false)
+	translateMessages(t, NewNXActionRegMove(48, 0, 0, moveSrc, moveDst), new(NXActionRegMove), nxRegMoveEquals)
+
+	outputFiled, _ := FindFieldHeaderByName("NXM_NX_REG1", false)
+	translateMessages(t, NewOutputFromField(outputFiled, NewNXRange(0, 31).ToOfsBits()), new(NXActionOutputReg), nxOutputRegEquals)
+	translateMessages(t, NewOutputFromFieldWithMaxLen(outputFiled, NewNXRange(0, 31).ToOfsBits(), uint16(0xfffe)), new(NXActionOutputReg), nxOutputRegEquals)
+
+	translateMessages(t, NewNXActionDecTTL(), new(NXActionDecTTL), nxDecTTLEquals)
+	translateMessages(t, NewNXActionDecTTLCntIDs(2, uint16(1), uint16(2)), new(NXActionDecTTLCntIDs), nxDecTTLCntIDsEquals)
+
+}
+
+func translateMessages(t *testing.T, act1, act2 Action, compare func(act1, act2 Action, stype uint16) bool) {
+	data, err := act1.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Failed to Marshal message: %v", err)
+	}
+	err = act2.UnmarshalBinary(data)
+	if err != nil {
+		t.Fatalf("Failed to Unmarshal NXActionCTNAT: %v", err)
+	}
+	if act1.Header().Type != act1.Header().Type || act1.Header().Type != ActionType_Experimenter {
+		t.Errorf("Action type is not equal")
+	}
+	nxHeader1 := new(NXActionHeader)
+	if err = nxHeader1.UnmarshalBinary(data); err != nil {
+		t.Fatalf("Failed to unMarshal NXHeader")
+	}
+	result := compare(act1, act2, nxHeader1.Subtype)
+	if !result {
+		t.Errorf("Unmarshaled object is not equals to original one")
+	}
+}
+
+func nxConjunctionEquals(o1, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_CNJUNCTION {
+		return false
+	}
+	obj1 := o1.(*NXActionConjunction)
+	obj2 := o2.(*NXActionConjunction)
+	if obj1.ID != obj2.ID {
+		return false
+	}
+	if obj1.NClause != obj2.NClause {
+		return false
+	}
+	if obj1.Clause != obj2.Clause {
+		return false
+	}
+	return true
+}
+
+func nxRegLoadEquals(o1, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_REG_LOAD {
+		return false
+	}
+	obj1 := o1.(*NXActionRegLoad)
+	obj2 := o2.(*NXActionRegLoad)
+	if obj1.OfsNbits != obj2.OfsNbits {
+		return false
+	}
+	if obj1.DstReg.Field != obj2.DstReg.Field {
+		return false
+	}
+	if obj1.Value != obj2.Value {
+		return false
+	}
+	return true
+}
+
+func nxRegMoveEquals(o1, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_REG_MOVE {
+		return false
+	}
+	obj1 := o1.(*NXActionRegMove)
+	obj2 := o2.(*NXActionRegMove)
+	if obj1.DstField.Field != obj2.DstField.Field {
+		return false
+	}
+	if obj1.SrcField.Field != obj2.SrcField.Field {
+		return false
+	}
+	if obj1.SrcOfs != obj2.SrcOfs {
+		return false
+	}
+	if obj1.DstOfs != obj2.DstOfs {
+		return false
+	}
+	if obj1.Nbits != obj2.Nbits {
+		return false
+	}
+	return true
+}
+
+func nxOutputRegEquals(o1, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_OUTPUT_REG {
+		return false
+	}
+	obj1 := o1.(*NXActionOutputReg)
+	obj2 := o2.(*NXActionOutputReg)
+	if obj1.SrcField.Field != obj2.SrcField.Field {
+		return false
+	}
+	if obj1.OfsNbits != obj2.OfsNbits {
+		return false
+	}
+	if obj1.MaxLen != obj2.MaxLen {
+		return false
+	}
+	return true
+}
+
+func nxDecTTLEquals(o1 Action, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_DEC_TTL {
+		return false
+	}
+	obj1 := o1.(*NXActionDecTTL)
+	obj2 := o2.(*NXActionDecTTL)
+	if obj1.controllers != obj2.controllers {
+		return false
+	}
+	if obj2.controllers != 0 {
+		return false
+	}
+	return true
+}
+
+func nxDecTTLCntIDsEquals(o1 Action, o2 Action, subtype uint16) bool {
+	if subtype != NXAST_DEC_TTL_CNT_IDS {
+		return false
+	}
+	obj1 := o1.(*NXActionDecTTLCntIDs)
+	obj2 := o2.(*NXActionDecTTLCntIDs)
+	if obj1.controllers != obj2.controllers {
+		return false
+	}
+	if len(obj1.cntIDs) != len(obj2.cntIDs) {
+		return false
+	}
+	obj1CntMap := make(map[uint16]bool)
+	for _, id := range obj1.cntIDs {
+		obj1CntMap[id] = true
+	}
+
+	for _, id := range obj2.cntIDs {
+		_, exist := obj1CntMap[id]
+		if !exist {
+			return false
+		}
+	}
+	return true
+}
+
+func testMatchFieldHeaderMarshalUnMarshal(tgtField *MatchField, t *testing.T) {
+	headerInt := tgtField.MarshalHeader()
+	testMFHeader := new(MatchField)
+	var data []byte = make([]byte, 4)
+	binary.BigEndian.PutUint32(data, headerInt)
+	_ = testMFHeader.UnmarshalHeader(data)
+	if testMFHeader.Class != tgtField.Class {
+		t.Errorf("Failed to UnmarshalHeader: class")
+	}
+	if testMFHeader.Field != tgtField.Field {
+		t.Errorf("Failed to UnmarshalHeader: field, test: %d, tgt: %d", testMFHeader.Field, tgtField.Field)
+	}
+	if testMFHeader.HasMask != tgtField.HasMask {
+		t.Errorf("Failed to UnmarshalHeader: mask")
+	}
+	if testMFHeader.Length != tgtField.Length {
+		t.Errorf("Failed to UnmarshalHeader: length")
+	}
+}

--- a/openflow13/openflow13.go
+++ b/openflow13/openflow13.go
@@ -261,7 +261,10 @@ func (p *PacketOut) UnmarshalBinary(data []byte) error {
 	n += 6 // for pad
 
 	for n < (n + p.ActionsLen) {
-		a := DecodeAction(data[n:])
+		a, err := DecodeAction(data[n:])
+		if err != nil {
+			return err
+		}
 		p.Actions = append(p.Actions, a)
 		n += a.Len()
 	}


### PR DESCRIPTION
1. Add support to match standard OF field: arp_sha, arp_tha, arp_spa, arp_tpa
2. Add support to match standard OF field: stcp_src/stcp_dst
3. Add support to match Nicira OF extension field: regN, ct_state, ct_mark,
   ct_zone, conj_id
4. Add support for standard OF action: dec_ttl
5. Add support for Nicira OF extension actions: conjunction, ct, load, move,
   resubmit, nat, output_reg, dec_ttl
6. Add public function to find MatchField by filed name. It is used to set
   extended actions: load, move, output_reg