### PR TITLE
Bugfix for lipOpenflow

### DIFF
--- a/openflow13/action.go
+++ b/openflow13/action.go
@@ -55,7 +55,7 @@ func (a *ActionHeader) MarshalBinary() (data []byte, err error) {
 }
 
 func (a *ActionHeader) UnmarshalBinary(data []byte) error {
-	if len(data) != 4 {
+	if len(data) < int(a.Len()) {
 		return errors.New("The []byte the wrong size to unmarshal an " +
 			"ActionHeader message.")
 	}

--- a/openflow13/match.go
+++ b/openflow13/match.go
@@ -367,14 +367,14 @@ func DecodeMatchField(class uint16, field uint8, data []byte) (util.Message, err
 			val = new(Uint32Message)
 		case NXM_NX_TUN_GBP_ID:
 		case NXM_NX_TUN_GBP_FLAGS:
-		case NXM_NX_TUN_METADAT0:
-		case NXM_NX_TUN_METADAT1:
-		case NXM_NX_TUN_METADAT2:
-		case NXM_NX_TUN_METADAT3:
-		case NXM_NX_TUN_METADAT4:
-		case NXM_NX_TUN_METADAT5:
-		case NXM_NX_TUN_METADAT6:
-		case NXM_NX_TUN_METADAT7:
+		case NXM_NX_TUN_METADATA0:
+		case NXM_NX_TUN_METADATA1:
+		case NXM_NX_TUN_METADATA2:
+		case NXM_NX_TUN_METADATA3:
+		case NXM_NX_TUN_METADATA4:
+		case NXM_NX_TUN_METADATA5:
+		case NXM_NX_TUN_METADATA6:
+		case NXM_NX_TUN_METADATA7:
 		case NXM_NX_TUN_FLAGS:
 		case NXM_NX_CT_STATE:
 			val = new(Uint32Message)
@@ -515,14 +515,14 @@ const (
 	NXM_NX_CONJ_ID       = 37  /* nicira extension: conj_id, conjunction ID for conjunctive match */
 	NXM_NX_TUN_GBP_ID    = 38  /* nicira extension: tun_gbp_id, GBP policy ID */
 	NXM_NX_TUN_GBP_FLAGS = 39  /* nicira extension: tun_gbp_flags, GBP policy Flags*/
-	NXM_NX_TUN_METADAT0  = 40  /* nicira extension: tun_metadata for Geneve header variable data */
-	NXM_NX_TUN_METADAT1  = 41  /* nicira extension: tun_metadata, for Geneve header variable data */
-	NXM_NX_TUN_METADAT2  = 42  /* nicira extension: tun_metadata, for Geneve header variable data */
-	NXM_NX_TUN_METADAT3  = 43  /* nicira extension: tun_metadata for Geneve header variable data */
-	NXM_NX_TUN_METADAT4  = 44  /* nicira extension: tun_metadata, for Geneve header variable data */
-	NXM_NX_TUN_METADAT5  = 45  /* nicira extension: tun_metadata, for Geneve header variable data */
-	NXM_NX_TUN_METADAT6  = 46  /* nicira extension: tun_metadata, for Geneve header variable data */
-	NXM_NX_TUN_METADAT7  = 47  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA0 = 40  /* nicira extension: tun_metadata for Geneve header variable data */
+	NXM_NX_TUN_METADATA1 = 41  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA2 = 42  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA3 = 43  /* nicira extension: tun_metadata for Geneve header variable data */
+	NXM_NX_TUN_METADATA4 = 44  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA5 = 45  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA6 = 46  /* nicira extension: tun_metadata, for Geneve header variable data */
+	NXM_NX_TUN_METADATA7 = 47  /* nicira extension: tun_metadata, for Geneve header variable data */
 	NXM_NX_TUN_FLAGS     = 104 /* nicira extension: tunnel Flags */
 	NXM_NX_CT_STATE      = 105 /* nicira extension: ct_state for conn_track */
 	NXM_NX_CT_ZONE       = 106 /* nicira extension: ct_zone for conn_track */

--- a/openflow13/nx_action.go
+++ b/openflow13/nx_action.go
@@ -46,7 +46,7 @@ const (
 	NXAST_SET_MPLS_TC      = 31 // Nicira extended action: set_mpls_tc
 	NXAST_OUTPUT_REG2      = 32 // Nicira extended action: output(port=port,max_len)
 	NXAST_REG_LOAD2        = 33 // Nicira extended action: load
-	NXAST_CNJUNCTION       = 34 // Nicira extended action: conjunction
+	NXAST_CONJUNCTION      = 34 // Nicira extended action: conjunction
 	NXAST_CT               = 35 // Nicira extended action: ct
 	NXAST_NAT              = 36 // Nicira extended action: nat, need to be along with ct action
 	NXAST_CONTROLLER2      = 37 // Nicira extended action: controller(userdata=xxx,pause)
@@ -155,7 +155,7 @@ func DecodeNxAction(data []byte) Action {
 	case NXAST_OUTPUT_REG2:
 		a = new(NXActionOutputReg)
 	case NXAST_REG_LOAD2:
-	case NXAST_CNJUNCTION:
+	case NXAST_CONJUNCTION:
 		a = new(NXActionConjunction)
 	case NXAST_CT:
 		a = new(NXActionConnTrack)
@@ -186,7 +186,7 @@ type NXActionConjunction struct {
 // NewNXActionConjunction creates NXActionConjunction, the action in flow entry is like conjunction(ID, Clause/nclause).
 func NewNXActionConjunction(clause uint8, nclause uint8, id uint32) *NXActionConjunction {
 	a := new(NXActionConjunction)
-	a.NXActionHeader = NewNxActionHeader(NXAST_CNJUNCTION)
+	a.NXActionHeader = NewNxActionHeader(NXAST_CONJUNCTION)
 	a.Length = a.NXActionHeader.Len() + 6
 	a.Clause = clause
 	a.NClause = nclause

--- a/openflow13/nx_match.go
+++ b/openflow13/nx_match.go
@@ -177,14 +177,9 @@ func newNXRegHeader(idx int, hasMask bool) *MatchField {
 
 func NewRegMatchField(idx int, data uint32, dataRng *NXRange) *MatchField {
 	var field *MatchField
-	if dataRng != nil {
-		field = newNXRegHeader(idx, true)
-	} else {
-		field = newNXRegHeader(idx, false)
-	}
+	field = newNXRegHeader(idx, dataRng != nil)
 
 	field.Value = newUint32Message(data)
-
 	if dataRng != nil {
 		field.Mask = newUint32Message(dataRng.ToUint32Mask())
 	}
@@ -206,13 +201,12 @@ func NewCTZoneMatchField(zone uint16) *MatchField {
 
 func NewCTMarkMatchField(mark uint32, mask *uint32) *MatchField {
 	var field *MatchField
-	if mask != nil {
-		field, _ = FindFieldHeaderByName("NXM_NX_CT_MARK", true)
-		field.Mask = newUint32Message(*mask)
-	} else {
-		field, _ = FindFieldHeaderByName("NXM_NX_CT_MARK", false)
-	}
+	field, _ = FindFieldHeaderByName("NXM_NX_CT_MARK", mask != nil)
+
 	field.Value = newUint32Message(mark)
+	if mask != nil {
+		field.Mask = newUint32Message(*mask)
+	}
 
 	return field
 }
@@ -250,13 +244,12 @@ func newCTLabel(data [16]byte) *CTLabel {
 
 func NewCTLabelMatchField(label [16]byte, mask *[16]byte) *MatchField {
 	var field *MatchField
-	if mask != nil {
-		field, _ = FindFieldHeaderByName("NXM_NX_CT_LABEL", true)
-		field.Mask = newCTLabel(*mask)
-	} else {
-		field, _ = FindFieldHeaderByName("NXM_NX_CT_LABEL", false)
-	}
+	field, _ = FindFieldHeaderByName("NXM_NX_CT_LABEL", mask != nil)
+
 	field.Value = newCTLabel(label)
+	if mask != nil {
+		field.Mask = newCTLabel(*mask)
+	}
 
 	return field
 }
@@ -270,11 +263,7 @@ func NewConjIDMatchField(conjID uint32) *MatchField {
 
 func NewNxARPShaMatchField(addr net.HardwareAddr, mask net.HardwareAddr) *MatchField {
 	var field *MatchField
-	if mask != nil {
-		field, _ = FindFieldHeaderByName("NXM_NX_ARP_SHA", true)
-	} else {
-		field, _ = FindFieldHeaderByName("NXM_NX_ARP_SHA", false)
-	}
+	field, _ = FindFieldHeaderByName("NXM_NX_ARP_SHA", mask != nil)
 
 	field.Value = &ArpXHaField{arpHa: addr}
 	if mask != nil {
@@ -286,11 +275,7 @@ func NewNxARPShaMatchField(addr net.HardwareAddr, mask net.HardwareAddr) *MatchF
 
 func NewNxARPThaMatchField(addr net.HardwareAddr, mask net.HardwareAddr) *MatchField {
 	var field *MatchField
-	if mask != nil {
-		field, _ = FindFieldHeaderByName("NXM_NX_ARP_THA", true)
-	} else {
-		field, _ = FindFieldHeaderByName("NXM_NX_ARP_THA", false)
-	}
+	field, _ = FindFieldHeaderByName("NXM_NX_ARP_THA", mask != nil)
 
 	field.Value = &ArpXHaField{arpHa: addr}
 	if mask != nil {
@@ -302,11 +287,7 @@ func NewNxARPThaMatchField(addr net.HardwareAddr, mask net.HardwareAddr) *MatchF
 
 func NewNxARPSpaMatchField(addr net.IP, mask net.IP) *MatchField {
 	var field *MatchField
-	if mask != nil {
-		field, _ = FindFieldHeaderByName("NXM_OF_ARP_SPA", true)
-	} else {
-		field, _ = FindFieldHeaderByName("NXM_OF_ARP_SPA", false)
-	}
+	field, _ = FindFieldHeaderByName("NXM_OF_ARP_SPA", mask != nil)
 
 	field.Value = &ArpXPaField{ArpPa: addr}
 	if mask != nil {
@@ -318,11 +299,7 @@ func NewNxARPSpaMatchField(addr net.IP, mask net.IP) *MatchField {
 
 func NewNxARPTpaMatchField(addr net.IP, mask net.IP) *MatchField {
 	var field *MatchField
-	if mask != nil {
-		field, _ = FindFieldHeaderByName("NXM_OF_ARP_TPA", true)
-	} else {
-		field, _ = FindFieldHeaderByName("NXM_OF_ARP_TPA", false)
-	}
+	field, _ = FindFieldHeaderByName("NXM_OF_ARP_TPA", mask != nil)
 
 	field.Value = &ArpXPaField{ArpPa: addr}
 	if mask != nil {

--- a/openflow13/nx_util.go
+++ b/openflow13/nx_util.go
@@ -142,14 +142,14 @@ var oxxFieldHeaderMap = map[string]*MatchField{
 	"NXM_NX_CT_LABEL":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_LABEL, 16),
 	"NXM_NX_TUN_IPV6_SRC":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV6_SRC, 16),
 	"NXM_NX_TUN_IPV6_DST":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV6_DST, 16),
-	"NXM_NX_TUN_METADATA0": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT0, 128),
-	"NXM_NX_TUN_METADATA1": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT1, 128),
-	"NXM_NX_TUN_METADATA2": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT2, 128),
-	"NXM_NX_TUN_METADATA3": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT3, 128),
-	"NXM_NX_TUN_METADATA4": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT4, 128),
-	"NXM_NX_TUN_METADATA5": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT5, 128),
-	"NXM_NX_TUN_METADATA6": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT6, 128),
-	"NXM_NX_TUN_METADATA7": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADAT7, 128),
+	"NXM_NX_TUN_METADATA0": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA0, 128),
+	"NXM_NX_TUN_METADATA1": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA1, 128),
+	"NXM_NX_TUN_METADATA2": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA2, 128),
+	"NXM_NX_TUN_METADATA3": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA3, 128),
+	"NXM_NX_TUN_METADATA4": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA4, 128),
+	"NXM_NX_TUN_METADATA5": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA5, 128),
+	"NXM_NX_TUN_METADATA6": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA6, 128),
+	"NXM_NX_TUN_METADATA7": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA7, 128),
 
 	"OXM_OF_IN_PORT":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IN_PORT, 4),
 	"OXM_OF_IN_PHY_PORT":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IN_PHY_PORT, 4),
@@ -176,7 +176,7 @@ var oxxFieldHeaderMap = map[string]*MatchField{
 	"OXM_OF_ARP_SPA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_SPA, 4),
 	"OXM_OF_ARP_TPA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_TPA, 4),
 	"OXM_OF_ARP_SHA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_SHA, 6),
-	"OXM_OF_ARP_THA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_SHA, 6),
+	"OXM_OF_ARP_THA":        newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_ARP_THA, 6),
 	"OXM_OF_IPV6_SRC":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_SRC, 16),
 	"OXM_OF_IPV6_DST":       newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_DST, 16),
 	"OXM_OF_IPV6_FLABEL":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_FLABEL, 4),
@@ -193,11 +193,11 @@ var oxxFieldHeaderMap = map[string]*MatchField{
 	"OXM_OF_IPV6_EXTHDR":    newMatchFieldHeader(OXM_CLASS_OPENFLOW_BASIC, OXM_FIELD_IPV6_EXTHDR, 2),
 }
 
-// oxxFieldHeaderWildMap is map to find target field header with mask using an OVS known OXX field name
-var oxxFieldHeaderWildMap map[string]*MatchField
+// oxmFieldHeaderWildMap is map to find target field header with mask using an OVS known OXM field name
+var oxmFieldHeaderWildMap map[string]*MatchField
 
 func init() {
-	oxxFieldHeaderWildMap = make(map[string]*MatchField)
+	oxmFieldHeaderWildMap = make(map[string]*MatchField)
 	for k, v := range oxxFieldHeaderMap {
 		field := &MatchField{
 			Class:   v.Class,
@@ -205,7 +205,7 @@ func init() {
 			HasMask: true,
 			Length:  v.Length * 2,
 		}
-		oxxFieldHeaderWildMap[k] = field
+		oxmFieldHeaderWildMap[k] = field
 	}
 }
 
@@ -214,7 +214,7 @@ func FindFieldHeaderByName(fieldName string, hasMask bool) (*MatchField, error) 
 	fieldKey := strings.ToUpper(fieldName)
 	var fieldsMap map[string]*MatchField
 	if hasMask {
-		fieldsMap = oxxFieldHeaderWildMap
+		fieldsMap = oxmFieldHeaderWildMap
 	} else {
 		fieldsMap = oxxFieldHeaderMap
 	}
@@ -237,12 +237,12 @@ func encodeOfsNbits(ofs uint16, nBits uint16) uint16 {
 	return ofs<<6 | (nBits - 1)
 }
 
-func encodeOfs(ofsNbits uint16) uint16 {
+func decodeOfs(ofsNbits uint16) uint16 {
 	return ofsNbits >> 6
 }
 
-func decodeNbits(ofsBnits uint16) uint16 {
-	return (ofsBnits & 0x3f) + 1
+func decodeNbits(ofsNbits uint16) uint16 {
+	return (ofsNbits & 0x3f) + 1
 }
 
 // NewNXRange creates a NXRange using start and end number.

--- a/openflow13/nxext_test.go
+++ b/openflow13/nxext_test.go
@@ -101,7 +101,7 @@ func TestNOfs(t *testing.T) {
 
 	encodeStartEnd := encodeOfsNbitsStartEnd(start, end)
 	encodeOfsNbits := encodeOfsNbits(ofs, nBits)
-	decodeOfs := encodeOfs(encodeOfsNbits)
+	decodeOfs := decodeOfs(encodeOfsNbits)
 	deCodeNbits := decodeNbits(encodeOfsNbits)
 
 	if encodeStartEnd != encodeOfsNbits {
@@ -280,7 +280,7 @@ func translateMessages(t *testing.T, act1, act2 Action, compare func(act1, act2 
 }
 
 func nxConjunctionEquals(o1, o2 Action, subtype uint16) bool {
-	if subtype != NXAST_CNJUNCTION {
+	if subtype != NXAST_CONJUNCTION {
 		return false
 	}
 	obj1 := o1.(*NXActionConjunction)


### PR DESCRIPTION
1. Fix bug where libOpenflow strictly requires action header length must
   be 4 bytes, it is not suitable for extension actions.
2. Fix several spelling issues in NX extensions.