### PR TITLE
Bugfix: Return a new MatchField copied from the field header map

### DIFF
--- a/openflow13/bundles.go
+++ b/openflow13/bundles.go
@@ -35,7 +35,7 @@ const (
 
 // Bundle property types
 const (
-	OFPBPT_EXPERIMENTER = 0XFFFF
+	OFPBPT_EXPERIMENTER = 0xFFFF
 )
 
 // Bundle error code.


### PR DESCRIPTION
Copy a new MatchField object from the object in the appropriate map, and return then it in function `FindFieldHeaderByName`. Otherwise, all goroutines are sharing the same MatchField object, and it could cause a race conditions.

Signed-off-by: wenyingd <wenyingd@vmware.com>