### PR TITLE
Fix case-insensitive import collision by "Sirupsen/logrus”

### DIFF
--- a/openflow13/flowmod.go
+++ b/openflow13/flowmod.go
@@ -3,8 +3,8 @@ package openflow13
 import (
 	"encoding/binary"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/libOpenflow/common"
+	log "github.com/sirupsen/logrus"
 )
 
 // ofp_flow_mod     1.3

--- a/openflow13/group.go
+++ b/openflow13/group.go
@@ -5,8 +5,8 @@ package openflow13
 import (
 	"encoding/binary"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/libOpenflow/common"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/openflow13/multipart.go
+++ b/openflow13/multipart.go
@@ -3,7 +3,7 @@ package openflow13
 import (
 	"encoding/binary"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/contiv/libOpenflow/common"
 	"github.com/contiv/libOpenflow/util"

--- a/stream_test.go
+++ b/stream_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/contiv/libOpenflow/common"
 	"github.com/contiv/libOpenflow/openflow13"
 	"github.com/contiv/libOpenflow/util"
+	"github.com/sirupsen/logrus"
 )
 
 var helloMessage *common.Hello

--- a/util/stream.go
+++ b/util/stream.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const numParserGoroutines = 25


### PR DESCRIPTION
The repo of logrus is renamed as “sirupsen/logrus” since 2018, all latest
versions are using the new name. And the original versions might cause
case-insensitive import collision when the OS is not case sentitive.

Use "github.com/sirupsen/logrus" instead of "github.com/Sirupsen/logrus"
in the imports.

Signed-off-by: wenyingd <wenyingd@vmware.com>