### PR TITLE
Add implementations for Nicira Extension: TLVMap and NXController

### DIFF
--- a/openflow13/bundles_test.go
+++ b/openflow13/bundles_test.go
@@ -1,52 +1,52 @@
 package openflow13
 
 import (
+	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBundleControl(t *testing.T) {
-	bundleCtrl := NewBundleControl()
-	bundleID := uint32(100)
-	bundleType := OFPBCT_OPEN_REQUEST
-	bundleCtrl.BundleID = bundleID
-	bundleCtrl.Type = bundleType
-	bundleCtrl.Flags = OFPBCT_ATOMIC
+	bundleCtrl := &BundleControl{
+		BundleID: uint32(100),
+		Type:     OFPBCT_OPEN_REQUEST,
+		Flags:    OFPBCT_ATOMIC,
+	}
 	data, err := bundleCtrl.MarshalBinary()
 	if err != nil {
 		t.Fatalf("Failed to Marshal BundleControl message: %v", err)
 	}
-	var bundleCtrl2 BundleControl
+	bundleCtrl2 := new(BundleControl)
 	err = bundleCtrl2.UnmarshalBinary(data)
 	if err != nil {
 		t.Fatalf("Failed to Unmarshal BundleControl message: %v", err)
 	}
-	assert.Equal(t, bundleCtrl.BundleID, bundleCtrl2.BundleID)
-	assert.Equal(t, bundleCtrl.Type, bundleCtrl2.Type)
-	assert.Equal(t, bundleCtrl.Flags, bundleCtrl2.Flags)
-	assert.Equal(t, bundleCtrl.Length, bundleCtrl2.Length)
+	if err := bundleCtrlEqual(bundleCtrl, bundleCtrl2); err != nil {
+		t.Errorf(err.Error())
+	}
 }
 
 func TestBundleAdd(t *testing.T) {
-	bundleAdd := NewBundleAdd()
-	bundleID := uint32(100)
-	bundleAdd.BundleID = bundleID
-	bundleAdd.Flags = OFPBCT_ATOMIC
-	bundleAdd.Message = NewFlowMod()
+	bundleAdd := &BundleAdd{
+		BundleID: uint32(100),
+		Flags:    OFPBCT_ATOMIC,
+		Message:  NewFlowMod(),
+	}
+
 	data, err := bundleAdd.MarshalBinary()
 	if err != nil {
 		t.Fatalf("Failed to Marshal BundleAdd message: %v", err)
 	}
-	var bundleAdd2 BundleAdd
+	bundleAdd2 := new(BundleAdd)
 	err = bundleAdd2.UnmarshalBinary(data)
 	if err != nil {
 		t.Fatalf("Failed to Unmarshal BundleAdd message: %v", err)
 	}
-	assert.Equal(t, bundleAdd.BundleID, bundleAdd2.BundleID)
-	assert.Equal(t, bundleAdd.Type, bundleAdd2.Type)
-	assert.Equal(t, bundleAdd.Flags, bundleAdd2.Flags)
-	assert.Equal(t, bundleAdd.Length, bundleAdd2.Length)
+	if err := bundleAddEqual(bundleAdd, bundleAdd2); err != nil {
+		t.Error(err.Error())
+	}
 }
 
 func TestBundleError(t *testing.T) {
@@ -54,12 +54,12 @@ func TestBundleError(t *testing.T) {
 	bundleError.Code = BEC_TIMEOUT
 	data, err := bundleError.MarshalBinary()
 	if err != nil {
-		t.Fatalf("Failed to Marshal BundleError message: %v", err)
+		t.Fatalf("Failed to Marshal VendorError message: %v", err)
 	}
-	var bundleErr2 BundleError
+	var bundleErr2 VendorError
 	err = bundleErr2.UnmarshalBinary(data)
 	if err != nil {
-		t.Fatalf("Failed to Unmarshal BundleError message: %v", err)
+		t.Fatalf("Failed to Unmarshal VendorError message: %v", err)
 	}
 	assert.Equal(t, bundleError.Type, bundleErr2.Type)
 	assert.Equal(t, bundleError.Code, bundleErr2.Code)
@@ -70,6 +70,7 @@ func TestBundleError(t *testing.T) {
 func TestVendorHeader(t *testing.T) {
 	vh1 := new(VendorHeader)
 	vh1.Header.Type = Type_Experimenter
+	vh1.Header.Length = vh1.Len()
 	vh1.Vendor = uint32(1000)
 	vh1.ExperimenterType = uint32(2000)
 	data, err := vh1.MarshalBinary()
@@ -84,4 +85,95 @@ func TestVendorHeader(t *testing.T) {
 	assert.Equal(t, vh1.Header.Type, vh2.Header.Type)
 	assert.Equal(t, vh1.Vendor, vh2.Vendor)
 	assert.Equal(t, vh1.ExperimenterType, vh2.ExperimenterType)
+}
+
+func TestBundleControlMessage(t *testing.T) {
+	testFunc := func(oriMessage *VendorHeader) {
+		data, err := oriMessage.MarshalBinary()
+		if err != nil {
+			t.Fatalf("Failed to Marshal message: %v", err)
+		}
+		newMessage := new(VendorHeader)
+		err = newMessage.UnmarshalBinary(data)
+		if err != nil {
+			t.Fatalf("Failed to UnMarshal message: %v", err)
+		}
+		bundleCtrl := oriMessage.VendorData.(*BundleControl)
+		bundleCtrl2, ok := newMessage.VendorData.(*BundleControl)
+		if !ok {
+			t.Fatalf("Failed to cast BundleControl from result")
+		}
+		if err = bundleCtrlEqual(bundleCtrl, bundleCtrl2); err != nil {
+			t.Error(err.Error())
+		}
+	}
+
+	bundleCtrl := &BundleControl{
+		BundleID: uint32(100),
+		Type:     OFPBCT_OPEN_REQUEST,
+		Flags:    OFPBCT_ATOMIC,
+	}
+	msg := NewBundleControl(bundleCtrl)
+	testFunc(msg)
+}
+
+func TestBundleAddMessage(t *testing.T) {
+	testFunc := func(oriMessage *VendorHeader) {
+		data, err := oriMessage.MarshalBinary()
+		if err != nil {
+			t.Fatalf("Failed to Marshal message: %v", err)
+		}
+		newMessage := new(VendorHeader)
+		err = newMessage.UnmarshalBinary(data)
+		if err != nil {
+			t.Fatalf("Failed to UnMarshal message: %v", err)
+		}
+		bundleAdd := oriMessage.VendorData.(*BundleAdd)
+		bundleAdd2, ok := newMessage.VendorData.(*BundleAdd)
+		if !ok {
+			t.Fatalf("Failed to cast BundleControl from result")
+		}
+		if err = bundleAddEqual(bundleAdd, bundleAdd2); err != nil {
+			t.Error(err.Error())
+		}
+	}
+
+	bundleAdd := &BundleAdd{
+		BundleID: uint32(100),
+		Flags:    OFPBCT_ATOMIC,
+		Message:  NewFlowMod(),
+	}
+	msg := NewBundleAdd(bundleAdd)
+	testFunc(msg)
+}
+
+func bundleCtrlEqual(bundleCtrl, bundleCtrl2 *BundleControl) error {
+	if bundleCtrl.BundleID != bundleCtrl2.BundleID {
+		return errors.New("bundle ID not equal")
+	}
+	if bundleCtrl.Type != bundleCtrl2.Type {
+		return errors.New("bundle Type not equal")
+	}
+	if bundleCtrl.Flags != bundleCtrl2.Flags {
+		return errors.New("bundle Flags not equal")
+	}
+	return nil
+}
+
+func bundleAddEqual(bundleAdd, bundleAdd2 *BundleAdd) error {
+	if bundleAdd.BundleID != bundleAdd2.BundleID {
+		return errors.New("bundle ID not equal")
+	}
+	if bundleAdd.Flags != bundleAdd2.Flags {
+		return errors.New("bundle Flags not equal")
+	}
+	msgData, _ := bundleAdd.Message.MarshalBinary()
+	msgData2, err := bundleAdd2.Message.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(msgData, msgData2) {
+		return errors.New("bundle message not equal")
+	}
+	return nil
 }

--- a/openflow13/nx_util.go
+++ b/openflow13/nx_util.go
@@ -84,6 +84,13 @@ const (
 	NXM_OF_ARP_TPA
 )
 
+// TLV_Table_Mod commands.
+const (
+	NXTTMC_ADD = iota
+	NXTTMC_DELETE
+	NXTTMC_CLEAR
+)
+
 func newMatchFieldHeader(class uint16, field uint8, length uint8) *MatchField {
 	var fieldLength = length
 	return &MatchField{Class: class, Field: field, Length: fieldLength, HasMask: false}
@@ -155,6 +162,13 @@ var oxxFieldHeaderMap = map[string]*MatchField{
 	"NXM_NX_CT_LABEL":      newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_LABEL, 16),
 	"NXM_NX_TUN_IPV6_SRC":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV6_SRC, 16),
 	"NXM_NX_TUN_IPV6_DST":  newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_IPV6_DST, 16),
+	"NXM_NX_CT_NW_PROTO":   newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_NW_PROTO, 1),
+	"NXM_NX_CT_NW_SRC":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_NW_SRC, 4),
+	"NXM_NX_CT_NW_DST":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_NW_DST, 4),
+	"NXM_NX_CT_IPV6_SRC":   newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_IPV6_SRC, 16),
+	"NXM_NX_CT_IPV6_DST":   newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_IPV6_DST, 16),
+	"NXM_NX_CT_TP_SRC":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_TP_SRC, 2),
+	"NXM_NX_CT_TP_DST":     newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_CT_TP_DST, 2),
 	"NXM_NX_TUN_METADATA0": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA0, 128),
 	"NXM_NX_TUN_METADATA1": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA1, 128),
 	"NXM_NX_TUN_METADATA2": newMatchFieldHeader(OXM_CLASS_NXM_1, NXM_NX_TUN_METADATA2, 128),

--- a/openflow13/nxt_message.go
+++ b/openflow13/nxt_message.go
@@ -1,0 +1,259 @@
+package openflow13
+
+import (
+	"encoding/binary"
+	"errors"
+
+	"github.com/contiv/libOpenflow/util"
+)
+
+// Nicira extension messages.
+const (
+	Type_SetFlowFormat     = 12
+	Type_FlowModTableId    = 15
+	Type_SetPacketInFormat = 16
+	Type_SetControllerId   = 20
+	Type_TlvTableMod       = 24
+	Type_TlvTableRequest   = 25
+	Type_TlvTableReply     = 26
+	Type_Resume            = 28
+	Type_CtFlushZone       = 29
+)
+
+// ofpet_tlv_table_mod_failed_code 1.3
+const (
+	OFPERR_NXTTMFC_BAD_COMMAND     = 16
+	OFPERR_NXTTMFC_BAD_OPT_LEN     = 17
+	ERR_NXTTMFC_BAD_FIELD_IDX      = 18
+	OFPERR_NXTTMFC_TABLE_FULL      = 19
+	OFPERR_NXTTMFC_ALREADY_MAPPED  = 20
+	OFPERR_NXTTMFC_DUP_ENTRY       = 21
+	OFPERR_NXTTMFC_INVALID_TLV_DEL = 38
+)
+
+func NewNXTVendorHeader(msgType uint32) *VendorHeader {
+	h := NewOfp13Header()
+	h.Type = Type_Experimenter
+	return &VendorHeader{
+		Header:           h,
+		Vendor:           NxExperimenterID,
+		ExperimenterType: msgType,
+	}
+}
+
+type ControllerID struct {
+	pad [6]byte
+	ID  uint16
+}
+
+func (c *ControllerID) Len() uint16 {
+	return uint16(len(c.pad) + 2)
+}
+
+func (c *ControllerID) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(c.Len()))
+	n := 6
+	binary.BigEndian.PutUint16(data[n:], c.ID)
+	return data, nil
+}
+
+func (c *ControllerID) UnmarshalBinary(data []byte) error {
+	if len(data) < int(c.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full ControllerID message")
+	}
+	n := 6
+	c.ID = binary.BigEndian.Uint16(data[n:])
+	return nil
+}
+
+func NewSetControllerID(id uint16) *VendorHeader {
+	msg := NewNXTVendorHeader(Type_SetControllerId)
+	msg.VendorData = &ControllerID{
+		ID: id,
+	}
+	return msg
+}
+
+type TLVTableMap struct {
+	OptClass  uint16
+	OptType   uint8
+	OptLength uint8
+	Index     uint16
+	pad       [2]byte
+}
+
+func (t *TLVTableMap) Len() uint16 {
+	return uint16(len(t.pad) + 6)
+}
+
+func (t *TLVTableMap) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, int(t.Len()))
+	n := 0
+	binary.BigEndian.PutUint16(data[n:], t.OptClass)
+	n += 2
+	data[n] = t.OptType
+	n += 1
+	data[n] = t.OptLength
+	n += 1
+	binary.BigEndian.PutUint16(data[n:], t.Index)
+	return data, nil
+}
+
+func (t *TLVTableMap) UnmarshalBinary(data []byte) error {
+	if len(data) < int(t.Len()) {
+		return errors.New("the []byte is too short to unmarshal a full TLVTableMap message")
+	}
+	n := 0
+	t.OptClass = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	t.OptType = data[n]
+	n += 1
+	t.OptLength = data[n]
+	n += 1
+	t.Index = binary.BigEndian.Uint16(data[n:])
+	return nil
+}
+
+type TLVTableMod struct {
+	Command uint16
+	pad     [6]byte
+	TlvMaps []*TLVTableMap
+}
+
+func (t *TLVTableMod) Len() uint16 {
+	length := uint16(8)
+	for _, tlvMap := range t.TlvMaps {
+		length += tlvMap.Len()
+	}
+	return length
+}
+
+func (t *TLVTableMod) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, t.Len())
+	n := 0
+	binary.BigEndian.PutUint16(data[n:], t.Command)
+	n += 2
+	n += 6
+	for _, tlvMap := range t.TlvMaps {
+		tlvData, err := tlvMap.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		copy(data[n:], tlvData)
+		n += len(tlvData)
+	}
+	return data, nil
+}
+
+func (t *TLVTableMod) UnmarshalBinary(data []byte) error {
+	if len(data) < 8 {
+		return errors.New("the []byte is too short to unmarshal a full TLVTableMod message")
+	}
+	n := 0
+	t.Command = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	n += 6
+
+	for n < len(data) {
+		tlvMap := new(TLVTableMap)
+		err := tlvMap.UnmarshalBinary(data[n:])
+		if err != nil {
+			return err
+		}
+		n += int(tlvMap.Len())
+		t.TlvMaps = append(t.TlvMaps, tlvMap)
+	}
+	return nil
+}
+
+func NewTLVTableMod(command uint16, tlvMaps []*TLVTableMap) *TLVTableMod {
+	return &TLVTableMod{
+		Command: command,
+		TlvMaps: tlvMaps,
+	}
+}
+
+func NewTLVTableModMessage(tlvMod *TLVTableMod) *VendorHeader {
+	msg := NewNXTVendorHeader(Type_TlvTableMod)
+	msg.VendorData = tlvMod
+	return msg
+}
+
+type TLVTableReply struct {
+	MaxSpace  uint32
+	MaxFields uint16
+	reserved  [10]byte
+	TlvMaps   []*TLVTableMap
+}
+
+func (t *TLVTableReply) Len() uint16 {
+	length := uint16(16)
+	for _, tlvMap := range t.TlvMaps {
+		length += tlvMap.Len()
+	}
+	return length
+}
+
+func (t *TLVTableReply) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, t.Len())
+	n := 0
+	binary.BigEndian.PutUint32(data[n:], t.MaxSpace)
+	n += 4
+	binary.BigEndian.PutUint16(data[n:], t.MaxFields)
+	n += 2
+	n += 10
+	for _, tlvMap := range t.TlvMaps {
+		tlvData, err := tlvMap.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		copy(data[n:], tlvData)
+		n += len(tlvData)
+	}
+	return data, nil
+}
+
+func (t *TLVTableReply) UnmarshalBinary(data []byte) error {
+	n := 0
+	t.MaxSpace = binary.BigEndian.Uint32(data[n:])
+	n += 4
+	t.MaxFields = binary.BigEndian.Uint16(data[n:])
+	n += 2
+	t.reserved = [10]byte{}
+	copy(t.reserved[0:], data[n:n+10])
+	n += 10
+	for n < len(data) {
+		tlvMap := new(TLVTableMap)
+		err := tlvMap.UnmarshalBinary(data[n:])
+		if err != nil {
+			return err
+		}
+		n += int(tlvMap.Len())
+		t.TlvMaps = append(t.TlvMaps, tlvMap)
+	}
+	return nil
+}
+
+func NewTLVTableRequest() *VendorHeader {
+	return NewNXTVendorHeader(Type_TlvTableRequest)
+}
+
+func decodeVendorData(experimenterType uint32, data []byte) (msg util.Message, err error) {
+	switch experimenterType {
+	case Type_SetControllerId:
+		msg = new(ControllerID)
+	case Type_TlvTableMod:
+		msg = new(TLVTableMod)
+	case Type_TlvTableReply:
+		msg = new(TLVTableReply)
+	case Type_BundleCtrl:
+		msg = new(BundleControl)
+	case Type_BundleAdd:
+		msg = new(BundleAdd)
+	}
+	err = msg.UnmarshalBinary(data)
+	if err != nil {
+		return nil, err
+	}
+	return msg, err
+}


### PR DESCRIPTION
1. tlv-map is used to set Geneve header. Add Nicira extension messages to
   get or modify tlv-map.
2. Add implementations to support Nicira extension: Set_Controller_ID and
   NXController.
3. Rename BundleError as VendorError.
4. Expand VendorHeader to support adding Vendor data in the message.
5. Use VendorHeader to send Bundle messages.
6. Expose data in Uint32Message and Uint16Message as public.